### PR TITLE
fix: proper reference to workflow step outputs

### DIFF
--- a/src/provider-upgrade.ts
+++ b/src/provider-upgrade.ts
@@ -26,7 +26,7 @@ export class ProviderUpgrade {
     });
 
     const newerVersionAvailable =
-      "${{ steps.check_version.new_version == 'available' }}";
+      "${{ steps.check_version.outputs.new_version == 'available' }}";
 
     workflow.addJobs({
       upgrade: {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -330,17 +330,17 @@ jobs:
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         env:
           CHECKPOINT_DISABLE: \\"1\\"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn compile
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn docgen
       - name: Create Pull Request
-        if: \${{ steps.check_version.new_version == 'available' }}
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: \\"chore: upgrade provider\\"
@@ -2592,17 +2592,17 @@ jobs:
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         env:
           CHECKPOINT_DISABLE: \\"1\\"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn compile
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn docgen
       - name: Create Pull Request
-        if: \${{ steps.check_version.new_version == 'available' }}
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: \\"chore: upgrade provider\\"
@@ -4854,17 +4854,17 @@ jobs:
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         env:
           CHECKPOINT_DISABLE: \\"1\\"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn compile
-      - if: \${{ steps.check_version.new_version == 'available' }}
+      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn docgen
       - name: Create Pull Request
-        if: \${{ steps.check_version.new_version == 'available' }}
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: \\"chore: upgrade provider\\"


### PR DESCRIPTION
Fixes #268 

Per the [documentation](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions), the `.outputs` property was missing from these lines. I manually override projen to [test this on an active repository](https://github.com/skeptools/cdktf-provider-slack/actions/runs/3298230485/jobs/5440066397), and it _does_ resolve the issue.