### PR TITLE
fix: namespace / npm scope

### DIFF
--- a/API.md
+++ b/API.md
@@ -2121,6 +2121,8 @@ public readonly githubNamespace: string;
 
 defaults to "cdktf" previously was "hashicorp".
 
+Used for GitHub org name and package scoping
+
 ---
 
 ##### `jsiiVersion`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.jsiiVersion"></a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
 
     const packageInfo: PackageInfo = {
       npm: {
-        name: `@${namespace}/provider-${providerName}`,
+        name: `@${githubNamespace}/provider-${providerName}`,
       },
       python: {
         distName: `${namespace}-cdktf-provider-${providerName.replace(

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
   readonly namespace?: string;
   /**
    * defaults to "cdktf"
-   * previously was "hashicorp"
+   * previously was "hashicorp". Used for GitHub org name and package scoping
    */
   readonly githubNamespace?: string;
   readonly mavenEndpoint?: string;
@@ -72,7 +72,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
     const nugetName = `${nugetOrg}.${pascalCase(
       namespace
     )}.Providers.${pascalCase(providerName)}`;
-    const mavenName = `com.${mavenOrg}.cdktf.providers.${getMavenName(
+    const mavenName = `com.${mavenOrg}.${namespace}.providers.${getMavenName(
       providerName
     )}`;
 
@@ -81,11 +81,11 @@ export class CdktfProviderProject extends cdk.JsiiProject {
         name: `@${githubNamespace}/provider-${providerName}`,
       },
       python: {
-        distName: `${namespace}-cdktf-provider-${providerName.replace(
+        distName: `${githubNamespace}-${namespace}-provider-${providerName.replace(
           /-/gi,
           "_"
         )}`,
-        module: `${namespace}_cdktf_provider_${providerName.replace(
+        module: `${githubNamespace}_${namespace}_provider_${providerName.replace(
           /-/gi,
           "_"
         )}`,

--- a/src/readme.ts
+++ b/src/readme.ts
@@ -6,7 +6,6 @@ export interface ReadmeFileOptions extends FileBaseOptions {
   providerName: string;
   providerVersion: string;
   packageInfo: PackageInfo;
-  githubNamespace: string;
 }
 
 export class ReadmeFile extends FileBase {
@@ -18,8 +17,9 @@ export class ReadmeFile extends FileBase {
   }
 
   protected synthesizeContent(resolver: IResolver) {
-    const { providerName, providerVersion, packageInfo, githubNamespace } =
-      resolver.resolve(this.options) as ReadmeFileOptions;
+    const { providerName, providerVersion, packageInfo } = resolver.resolve(
+      this.options
+    ) as ReadmeFileOptions;
 
     return `
 # Terraform CDK ${providerName} Provider ${providerVersion}
@@ -61,9 +61,9 @@ The Maven package is available at [https://mvnrepository.com/artifact/${packageI
 
 ### Go
 
-The go package is generated into the [\`github.com/${githubNamespace}/cdktf-provider-${providerName}-go\`](https://github.com/${githubNamespace}/cdktf-provider-${providerName}-go) package.
+The go package is generated into the [\`${packageInfo.publishToGo?.moduleName}\`](https://${packageInfo.publishToGo?.moduleName}) package.
 
-\`go get github.com/${githubNamespace}/cdktf-provider-${providerName}-go/${providerName}\`
+\`go get ${packageInfo.publishToGo?.moduleName}/${packageInfo.publishToGo?.packageName}\`
 
 ## Docs
 


### PR DESCRIPTION
Fixes #270 

The first commit is all that is needed to resolve the issue.

The second commit is a bit of cleanup based on my interpretation of the difference between `namespace` (which I was taking to mean "cdktf" or something else) and `githubNamespace` (which I was seeing used as the GitHub org for both the origin repo and the destination packages). This commit is where there may be side effects - but _only if downstream repos are using non-defaults for `namespace`_. If all downstream repos are using the defaults, this change should result in zero changes in those repos. If you are uncomfortable with the change management around this, I will simply revert the second commit and leave the first one - which is all I really need. But I do think this cleanup will prevent some bugs down the road.