### PR TITLE
feat: Better release commits

### DIFF
--- a/src/cdktf-config.ts
+++ b/src/cdktf-config.ts
@@ -65,6 +65,44 @@ export class CdktfConfig {
     );
     project.setScript("test", "jest --passWithNoTests");
     project.addFields({ publishConfig: { access: "public" } });
+    project.addFields({
+      "standard-version": {
+        types: [
+          {
+            type: "feat",
+            section: "Features",
+          },
+          {
+            type: "fix",
+            section: "Bug Fixes",
+          },
+          {
+            type: "chore",
+            section: "Updates",
+          },
+          {
+            type: "docs",
+            hidden: true,
+          },
+          {
+            type: "style",
+            hidden: true,
+          },
+          {
+            type: "refactor",
+            hidden: true,
+          },
+          {
+            type: "perf",
+            hidden: true,
+          },
+          {
+            type: "test",
+            hidden: true,
+          },
+        ],
+      },
+    });
 
     // set provider name and version from version.json (if it exists yet)
     const versionFile = path.resolve(project.outdir, "src/version.json");

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -330,11 +330,19 @@ jobs:
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
+      - name: get provider current version
+        id: current_version
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: echo \\"value=$(jq -r '.cdktf.provider.version' package.json)\\" >> $GITHUB_OUTPUT
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         env:
           CHECKPOINT_DISABLE: \\"1\\"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
+      - name: get provider updated version
+        id: new_version
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: echo \\"value=$(jq -r '. | to_entries[] | .value' src/version.json)\\" >> $GITHUB_OUTPUT
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn compile
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
@@ -343,7 +351,7 @@ jobs:
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: \\"chore: upgrade provider\\"
+          commit-message: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
           branch: auto/provider-upgrade
           title: \\"chore: upgrade provider\\"
           body: This PR upgrades provider to the latest version
@@ -1976,6 +1984,42 @@ The repository is managed by [Repository Manager](https://github.com/hashicorp/c
       "watch": "npx projen watch",
     },
     "stability": "stable",
+    "standard-version": Object {
+      "types": Array [
+        Object {
+          "section": "Features",
+          "type": "feat",
+        },
+        Object {
+          "section": "Bug Fixes",
+          "type": "fix",
+        },
+        Object {
+          "section": "Updates",
+          "type": "chore",
+        },
+        Object {
+          "hidden": true,
+          "type": "docs",
+        },
+        Object {
+          "hidden": true,
+          "type": "style",
+        },
+        Object {
+          "hidden": true,
+          "type": "refactor",
+        },
+        Object {
+          "hidden": true,
+          "type": "perf",
+        },
+        Object {
+          "hidden": true,
+          "type": "test",
+        },
+      ],
+    },
     "types": "lib/index.d.ts",
     "version": "0.0.0",
   },
@@ -2592,11 +2636,19 @@ jobs:
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
+      - name: get provider current version
+        id: current_version
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: echo \\"value=$(jq -r '.cdktf.provider.version' package.json)\\" >> $GITHUB_OUTPUT
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         env:
           CHECKPOINT_DISABLE: \\"1\\"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
+      - name: get provider updated version
+        id: new_version
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: echo \\"value=$(jq -r '. | to_entries[] | .value' src/version.json)\\" >> $GITHUB_OUTPUT
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn compile
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
@@ -2605,7 +2657,7 @@ jobs:
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: \\"chore: upgrade provider\\"
+          commit-message: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
           branch: auto/provider-upgrade
           title: \\"chore: upgrade provider\\"
           body: This PR upgrades provider to the latest version
@@ -4259,6 +4311,42 @@ The repository is managed by [Repository Manager](https://github.com/hashicorp/c
       "watch": "npx projen watch",
     },
     "stability": "stable",
+    "standard-version": Object {
+      "types": Array [
+        Object {
+          "section": "Features",
+          "type": "feat",
+        },
+        Object {
+          "section": "Bug Fixes",
+          "type": "fix",
+        },
+        Object {
+          "section": "Updates",
+          "type": "chore",
+        },
+        Object {
+          "hidden": true,
+          "type": "docs",
+        },
+        Object {
+          "hidden": true,
+          "type": "style",
+        },
+        Object {
+          "hidden": true,
+          "type": "refactor",
+        },
+        Object {
+          "hidden": true,
+          "type": "perf",
+        },
+        Object {
+          "hidden": true,
+          "type": "test",
+        },
+      ],
+    },
     "types": "lib/index.d.ts",
     "version": "0.0.0",
   },
@@ -4854,11 +4942,19 @@ jobs:
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
+      - name: get provider current version
+        id: current_version
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: echo \\"value=$(jq -r '.cdktf.provider.version' package.json)\\" >> $GITHUB_OUTPUT
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         env:
           CHECKPOINT_DISABLE: \\"1\\"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
+      - name: get provider updated version
+        id: new_version
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: echo \\"value=$(jq -r '. | to_entries[] | .value' src/version.json)\\" >> $GITHUB_OUTPUT
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
         run: yarn compile
       - if: \${{ steps.check_version.outputs.new_version == 'available' }}
@@ -4867,7 +4963,7 @@ jobs:
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: \\"chore: upgrade provider\\"
+          commit-message: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
           branch: auto/provider-upgrade
           title: \\"chore: upgrade provider\\"
           body: This PR upgrades provider to the latest version
@@ -6500,6 +6596,42 @@ The repository is managed by [Repository Manager](https://github.com/hashicorp/c
       "watch": "npx projen watch",
     },
     "stability": "stable",
+    "standard-version": Object {
+      "types": Array [
+        Object {
+          "section": "Features",
+          "type": "feat",
+        },
+        Object {
+          "section": "Bug Fixes",
+          "type": "fix",
+        },
+        Object {
+          "section": "Updates",
+          "type": "chore",
+        },
+        Object {
+          "hidden": true,
+          "type": "docs",
+        },
+        Object {
+          "hidden": true,
+          "type": "style",
+        },
+        Object {
+          "hidden": true,
+          "type": "refactor",
+        },
+        Object {
+          "hidden": true,
+          "type": "perf",
+        },
+        Object {
+          "hidden": true,
+          "type": "test",
+        },
+      ],
+    },
     "types": "lib/index.d.ts",
     "version": "0.0.0",
   },


### PR DESCRIPTION
Related to: https://github.com/hashicorp/terraform-cdk/issues/1976

This PR does the following:

- When a provider version changes, it mentions both the old and new version in the commit
- Enable `standard-version` to include `chore` commits in the change log published with each release.

This fixes part of the issue above, and another PR will be created on https://github.com/cdktf/cdktf-repository-manager which is also responsible for some Pull Requests made on the pre-built provider repositories.