### PR TITLE
fix: update pr title for prebuilt provider upgrade

### DIFF
--- a/src/provider-upgrade.ts
+++ b/src/provider-upgrade.ts
@@ -75,8 +75,8 @@ export class ProviderUpgrade {
             with: {
               "commit-message": `chore: upgrade provider from \`${currentVersion}\` to version \`${newVersion}\``,
               branch: "auto/provider-upgrade",
-              title: "chore: upgrade provider",
-              body: "This PR upgrades provider to the latest version",
+              title: `chore: upgrade provider from \`${currentVersion}\` to version \`${newVersion}\``,
+              body: `This PR upgrades provider to version ${newVersion}`,
               labels: "automerge",
               token: "${{ secrets.GH_TOKEN }}",
               "delete-branch": true,

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -353,8 +353,8 @@ jobs:
         with:
           commit-message: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
           branch: auto/provider-upgrade
-          title: \\"chore: upgrade provider\\"
-          body: This PR upgrades provider to the latest version
+          title: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
+          body: This PR upgrades provider to version \${{ steps.new_version.outputs.value }}
           labels: automerge
           token: \${{ secrets.GH_TOKEN }}
           delete-branch: true
@@ -2659,8 +2659,8 @@ jobs:
         with:
           commit-message: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
           branch: auto/provider-upgrade
-          title: \\"chore: upgrade provider\\"
-          body: This PR upgrades provider to the latest version
+          title: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
+          body: This PR upgrades provider to version \${{ steps.new_version.outputs.value }}
           labels: automerge
           token: \${{ secrets.GH_TOKEN }}
           delete-branch: true
@@ -4965,8 +4965,8 @@ jobs:
         with:
           commit-message: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
           branch: auto/provider-upgrade
-          title: \\"chore: upgrade provider\\"
-          body: This PR upgrades provider to the latest version
+          title: \\"chore: upgrade provider from \`\${{ steps.current_version.outputs.value }}\` to version \`\${{ steps.new_version.outputs.value }}\`\\"
+          body: This PR upgrades provider to version \${{ steps.new_version.outputs.value }}
           labels: automerge
           token: \${{ secrets.GH_TOKEN }}
           delete-branch: true


### PR DESCRIPTION
 The previous change changes the commit message which contains the provider versions, but didn't update the PR title. Unfortunately, I didn't realize that the updates will have the PR titles and not commit messages. This PR fixes that.