### PR TITLE
fix: fix current version lookup for providers with uppercase letters

### DIFF
--- a/src/scripts/check-for-upgrades.ts
+++ b/src/scripts/check-for-upgrades.ts
@@ -109,7 +109,7 @@ async function cdktfVersionMajorChanged() {
 
 async function getCurrentProviderVersion() {
   const json = require("../src/version.json");
-  return json[\`registry.terraform.io/\${FQ_PROVIDER_NAME}\`];
+  return json[\`registry.terraform.io/\${FQ_PROVIDER_NAME.toLowerCase()}\`];
 }
 
 // SEE NOTICE AT THE TOP WHY THIS IS INLINED CURRENTLY

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2101,7 +2101,7 @@ async function cdktfVersionMajorChanged() {
 
 async function getCurrentProviderVersion() {
   const json = require(\\"../src/version.json\\");
-  return json[\`registry.terraform.io/\${FQ_PROVIDER_NAME}\`];
+  return json[\`registry.terraform.io/\${FQ_PROVIDER_NAME.toLowerCase()}\`];
 }
 
 // SEE NOTICE AT THE TOP WHY THIS IS INLINED CURRENTLY
@@ -4428,7 +4428,7 @@ async function cdktfVersionMajorChanged() {
 
 async function getCurrentProviderVersion() {
   const json = require(\\"../src/version.json\\");
-  return json[\`registry.terraform.io/\${FQ_PROVIDER_NAME}\`];
+  return json[\`registry.terraform.io/\${FQ_PROVIDER_NAME.toLowerCase()}\`];
 }
 
 // SEE NOTICE AT THE TOP WHY THIS IS INLINED CURRENTLY
@@ -6713,7 +6713,7 @@ async function cdktfVersionMajorChanged() {
 
 async function getCurrentProviderVersion() {
   const json = require(\\"../src/version.json\\");
-  return json[\`registry.terraform.io/\${FQ_PROVIDER_NAME}\`];
+  return json[\`registry.terraform.io/\${FQ_PROVIDER_NAME.toLowerCase()}\`];
 }
 
 // SEE NOTICE AT THE TOP WHY THIS IS INLINED CURRENTLY


### PR DESCRIPTION
fix: fix current version lookup for providers with uppercase letters

We currently have 'Snowflake-Labs/snowflake' defined in a config. But the generated versions.json file is all lower-case.

This failed the upgrade script for this (and possibly other providers). Closes https://github.com/hashicorp/terraform-cdk/issues/2267