### PR TITLE
fix:  readme provider link

### DIFF
--- a/API.md
+++ b/API.md
@@ -2181,6 +2181,16 @@ defaults to "HashiCorp".
 
 ---
 
+##### `terraformNamespace`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.terraformNamespace"></a>
+
+```typescript
+public readonly terraformNamespace: string;
+```
+
+- *Type:* `string`
+
+---
+
 ##### `useCustomGithubRunner`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.useCustomGithubRunner"></a>
 
 ```typescript

--- a/src/cdktf-config.ts
+++ b/src/cdktf-config.ts
@@ -8,8 +8,8 @@ const CDKTF_JSON_FILE = "cdktf.json";
 
 interface CdktfConfigOptions {
   terraformProvider: string;
-  terraformNamespace: string;
   providerName: string;
+  fqproviderName: string;
   providerVersion: string;
   cdktfVersion: string;
   constructsVersion: string;
@@ -150,6 +150,6 @@ export class CdktfConfig {
       },
     });
 
-    new ReadmeFile(project, "README.md", options);
+    new ReadmeFile(project, "README.md", { ...options });
   }
 }

--- a/src/cdktf-config.ts
+++ b/src/cdktf-config.ts
@@ -8,6 +8,7 @@ const CDKTF_JSON_FILE = "cdktf.json";
 
 interface CdktfConfigOptions {
   terraformProvider: string;
+  terraformNamespace: string;
   providerName: string;
   providerVersion: string;
   cdktfVersion: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ const version = require("../version.json").version;
 export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
   readonly useCustomGithubRunner?: boolean;
   readonly terraformProvider: string;
-  readonly terraformNamespace?: string;
   readonly cdktfVersion: string;
   readonly constructsVersion: string;
   readonly jsiiVersion?: string;
@@ -50,7 +49,6 @@ export class CdktfProviderProject extends cdk.JsiiProject {
   constructor(options: CdktfProviderProjectOptions) {
     const {
       terraformProvider,
-      terraformNamespace = "terraform-providers",
       workflowContainerImage = "hashicorp/jsii-terraform",
       cdktfVersion,
       constructsVersion,
@@ -197,8 +195,8 @@ export class CdktfProviderProject extends cdk.JsiiProject {
 
     new CdktfConfig(this, {
       terraformProvider,
-      terraformNamespace,
       providerName,
+      fqproviderName,
       providerVersion,
       cdktfVersion,
       constructsVersion,
@@ -208,7 +206,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
     });
     const upgradeScript = new CheckForUpgradesScriptFile(this, {
       providerVersion,
-      fqproviderName,
+      fqproviderName: fqproviderName,
     });
     new ProviderUpgrade(this, {
       checkForUpgradesScriptPath: upgradeScript.path,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ const version = require("../version.json").version;
 export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
   readonly useCustomGithubRunner?: boolean;
   readonly terraformProvider: string;
+  readonly terraformNamespace?: string;
   readonly cdktfVersion: string;
   readonly constructsVersion: string;
   readonly jsiiVersion?: string;
@@ -49,6 +50,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
   constructor(options: CdktfProviderProjectOptions) {
     const {
       terraformProvider,
+      terraformNamespace = "terraform-providers",
       workflowContainerImage = "hashicorp/jsii-terraform",
       cdktfVersion,
       constructsVersion,
@@ -195,6 +197,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
 
     new CdktfConfig(this, {
       terraformProvider,
+      terraformNamespace,
       providerName,
       providerVersion,
       cdktfVersion,

--- a/src/readme.ts
+++ b/src/readme.ts
@@ -3,6 +3,7 @@ import { PackageInfo } from "./package-info";
 
 export interface ReadmeFileOptions extends FileBaseOptions {
   terraformProvider: string;
+  terraformNamespace: string;
   providerName: string;
   providerVersion: string;
   packageInfo: PackageInfo;
@@ -17,9 +18,8 @@ export class ReadmeFile extends FileBase {
   }
 
   protected synthesizeContent(resolver: IResolver) {
-    const { providerName, providerVersion, packageInfo } = resolver.resolve(
-      this.options
-    ) as ReadmeFileOptions;
+    const { providerName, terraformNamespace, providerVersion, packageInfo } =
+      resolver.resolve(this.options) as ReadmeFileOptions;
 
     return `
 # Terraform CDK ${providerName} Provider ${providerVersion}
@@ -77,7 +77,7 @@ This project is explicitly not tracking the Terraform ${providerName} Provider v
 These are the upstream dependencies:
 
 - [Terraform CDK](https://cdk.tf)
-- [Terraform ${providerName} Provider](https://github.com/terraform-providers/terraform-provider-${providerName})
+- [Terraform ${providerName} Provider](https://github.com/${terraformNamespace}/terraform-provider-${providerName})
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.

--- a/src/readme.ts
+++ b/src/readme.ts
@@ -2,9 +2,8 @@ import { FileBase, FileBaseOptions, IResolver, Project } from "projen";
 import { PackageInfo } from "./package-info";
 
 export interface ReadmeFileOptions extends FileBaseOptions {
-  terraformProvider: string;
-  terraformNamespace: string;
   providerName: string;
+  fqproviderName: string;
   providerVersion: string;
   packageInfo: PackageInfo;
 }
@@ -18,8 +17,15 @@ export class ReadmeFile extends FileBase {
   }
 
   protected synthesizeContent(resolver: IResolver) {
-    const { providerName, terraformNamespace, providerVersion, packageInfo } =
+    const { providerName, fqproviderName, providerVersion, packageInfo } =
       resolver.resolve(this.options) as ReadmeFileOptions;
+
+    const fqpnURL = fqproviderName.includes("/")
+      ? fqproviderName
+      : `hashicorp/${fqproviderName}`;
+    const versionURL = providerVersion
+      ? providerVersion.replace("~> ", "").concat(".0")
+      : "";
 
     return `
 # Terraform CDK ${providerName} Provider ${providerVersion}
@@ -77,7 +83,8 @@ This project is explicitly not tracking the Terraform ${providerName} Provider v
 These are the upstream dependencies:
 
 - [Terraform CDK](https://cdk.tf)
-- [Terraform ${providerName} Provider](https://github.com/${terraformNamespace}/terraform-provider-${providerName})
+- [Terraform ${providerName} Provider](https://registry.terraform.io/providers/${fqpnURL}/${versionURL})
+    - This is the minimum version being tracked- (to find the latest look to our releases)[https://github.com/cdktf/cdktf-provider-${providerName}/releases]
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1831,7 +1831,8 @@ This project is explicitly not tracking the Terraform random Provider version 1:
 These are the upstream dependencies:
 
 - [Terraform CDK](https://cdk.tf)
-- [Terraform random Provider](https://github.com/terraform-providers/terraform-provider-random)
+- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/)
+    - This is the minimum version being tracked- (to find the latest look to our releases)[https://github.com/cdktf/cdktf-provider-random/releases]
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.
@@ -4167,7 +4168,8 @@ This project is explicitly not tracking the Terraform random Provider version 1:
 These are the upstream dependencies:
 
 - [Terraform CDK](https://cdk.tf)
-- [Terraform random Provider](https://github.com/terraform-providers/terraform-provider-random)
+- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/)
+    - This is the minimum version being tracked- (to find the latest look to our releases)[https://github.com/cdktf/cdktf-provider-random/releases]
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.
@@ -6458,7 +6460,8 @@ This project is explicitly not tracking the Terraform random Provider version 1:
 These are the upstream dependencies:
 
 - [Terraform CDK](https://cdk.tf)
-- [Terraform random Provider](https://github.com/terraform-providers/terraform-provider-random)
+- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/)
+    - This is the minimum version being tracked- (to find the latest look to our releases)[https://github.com/cdktf/cdktf-provider-random/releases]
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -70,3 +70,15 @@ test("sets resolution for yargs", () => {
     "17.0.13"
   );
 });
+
+test("README contains provided Namespace", () => {
+  const snapshot = synthSnapshot(
+    getProject({ terraformNamespace: "test-naming" })
+  );
+
+  expect(snapshot["README.md"]).toEqual(
+    expect.stringContaining(
+      "- [Terraform random Provider](https://github.com/test-naming/terraform-provider-random)"
+    )
+  );
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -72,13 +72,29 @@ test("sets resolution for yargs", () => {
 });
 
 test("README contains provided Namespace", () => {
-  const snapshot = synthSnapshot(
-    getProject({ terraformNamespace: "test-naming" })
+  const snapshotWithVersion = synthSnapshot(
+    getProject({ terraformProvider: "random@~> 3.1" })
   );
 
-  expect(snapshot["README.md"]).toEqual(
+  const snapshotWithoutVersion = synthSnapshot(
+    getProject({ terraformProvider: "random" })
+  );
+
+  expect(snapshotWithVersion["README.md"]).toEqual(
     expect.stringContaining(
-      "- [Terraform random Provider](https://github.com/test-naming/terraform-provider-random)"
-    )
+      "- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/3.1.0)"
+    ) &&
+      expect.stringContaining(
+        "- This is the minimum version being tracked- (to find the latest look to our releases)[https://github.com/cdktf/cdktf-provider-random/releases]"
+      )
+  );
+
+  expect(snapshotWithoutVersion["README.md"]).toEqual(
+    expect.stringContaining(
+      "- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/)"
+    ) &&
+      expect.stringContaining(
+        "- This is the minimum version being tracked- (to find the latest look to our releases)[https://github.com/cdktf/cdktf-provider-random/releases]"
+      )
   );
 });


### PR DESCRIPTION
Link provided under Versioning in README points to the Terraform Registry of the minimum tracked version 