### PR TITLE
chore: Add repo name to make CLI work without checking out the repo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,6 +250,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
     new NextVersionPr(this, "${{ secrets.GITHUB_TOKEN }}");
     new AlertOpenPrs(this, {
       slackWebhookUrl: "${{ secrets.ALERT_PRS_SLACK_WEBHOOK_URL }}",
+      repository,
     });
 
     new ShouldReleaseScriptFile(this, {});

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -46,7 +46,7 @@ name: alert-open-prs
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: \\"* */1 * * 1-5\\"
+    - cron: \\"* */12 * * 1-5\\"
 jobs:
   check-open-prs:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         env:
           GH_TOKEN: \${{ github.token }}
         run: |-
-          PR_LINKS=$(gh pr list --state open --search \\"created:<$(date -d '-2hours' +%FT%TZ)\\" --json url --jq \\"map(.url)\\" )
+          PR_LINKS=$(gh pr list --state open --repo=\\"cdktf/cdktf-provider-random\\" --search \\"created:<$(date -d '-2hours' +%FT%TZ)\\" --json url --jq \\"map(.url)\\" )
           if [ \\"$PR_LINKS\\" == \\"[]\\" ]; then
             echo \\"No PRs open for more than 2 hour(s)\\"
           else
@@ -2461,7 +2461,7 @@ name: alert-open-prs
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: \\"* */1 * * 1-5\\"
+    - cron: \\"* */12 * * 1-5\\"
 jobs:
   check-open-prs:
     runs-on: ubuntu-latest
@@ -2474,7 +2474,7 @@ jobs:
         env:
           GH_TOKEN: \${{ github.token }}
         run: |-
-          PR_LINKS=$(gh pr list --state open --search \\"created:<$(date -d '-2hours' +%FT%TZ)\\" --json url --jq \\"map(.url)\\" )
+          PR_LINKS=$(gh pr list --state open --repo=\\"cdktf/cdktf-provider-random\\" --search \\"created:<$(date -d '-2hours' +%FT%TZ)\\" --json url --jq \\"map(.url)\\" )
           if [ \\"$PR_LINKS\\" == \\"[]\\" ]; then
             echo \\"No PRs open for more than 2 hour(s)\\"
           else
@@ -4921,7 +4921,7 @@ name: alert-open-prs
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: \\"* */1 * * 1-5\\"
+    - cron: \\"* */12 * * 1-5\\"
 jobs:
   check-open-prs:
     runs-on: ubuntu-latest
@@ -4934,7 +4934,7 @@ jobs:
         env:
           GH_TOKEN: \${{ github.token }}
         run: |-
-          PR_LINKS=$(gh pr list --state open --search \\"created:<$(date -d '-2hours' +%FT%TZ)\\" --json url --jq \\"map(.url)\\" )
+          PR_LINKS=$(gh pr list --state open --repo=\\"cdktf/cdktf-provider-random\\" --search \\"created:<$(date -d '-2hours' +%FT%TZ)\\" --json url --jq \\"map(.url)\\" )
           if [ \\"$PR_LINKS\\" == \\"[]\\" ]; then
             echo \\"No PRs open for more than 2 hour(s)\\"
           else


### PR DESCRIPTION
Also, move the cadence of PRs checking to twice a day

The reason for reducing the check is that it pollutes our github actions and thus makes the [dashboard](https://mutahhir.github.io/check-prebuilt-provider-status/) less useful. I think it's possible to improve that logic, but we also don't need hourly cadence for this IMO.