### PR TITLE
fix: limit autoclose workflow to issues only

### DIFF
--- a/src/auto-close-community-issues.ts
+++ b/src/auto-close-community-issues.ts
@@ -5,7 +5,7 @@ interface AutoCloseCommunityIssuesOptions {
   providerName: string;
 }
 /**
- * Automatically closes issues and PRs reported by non-collaborators since this isn't the right place for them.
+ * Automatically closes issues reported by non-collaborators since this isn't the right place for them.
  */
 export class AutoCloseCommunityIssues {
   constructor(
@@ -19,9 +19,6 @@ export class AutoCloseCommunityIssues {
 
     workflow.on({
       issues: {
-        types: ["opened"],
-      },
-      pullRequest: {
         types: ["opened"],
       },
     });


### PR DESCRIPTION
Kudos to Daniel for figuring out that "PR opened" type events send an entirely different payload and it's not currently possible to respond to PRs in the same way as issues. Limiting this to just issues for now.