### PR TITLE
chore: randomize the time when lock workflow runs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,7 +3,7 @@
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 57 12 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest

--- a/src/lock-issues.ts
+++ b/src/lock-issues.ts
@@ -13,7 +13,13 @@ export class LockIssues {
     if (!workflow) throw new Error("no workflow defined");
 
     workflow.on({
-      schedule: [{ cron: "20 2 * * *" }],
+      schedule: [
+        {
+          cron: `${Math.floor(Math.random() * 60)} ${Math.floor(
+            Math.random() * 24
+          )} * * *`,
+        },
+      ],
     });
 
     workflow.addJob("lock", {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -321,7 +321,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 47 11 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -2762,7 +2762,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 54 22 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -5206,7 +5206,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 41 6 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've been getting a lot of notifications about the lock workflow hitting rate limits which I think is happening because every prebuilt provider is trying to run this workflow at the same time. This randomizes the time, which I assume should lead to the different repos running it at different times.