### PR TITLE
fix: temporarily disable golang documentation generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -319,7 +319,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
     // There is no nice way to tell jsii-docgen to generate docs into a folder so I went this route
     (
       this.tasks.tryFind("docgen")!.steps![0] as any
-    ).exec = `rm -rf docs && mkdir docs && jsii-docgen --split-by-submodule -l typescript -l python -l java -l csharp -l go && mv *.*.md docs`;
+    ).exec = `rm -rf docs && mkdir docs && jsii-docgen --split-by-submodule -l typescript -l python -l java -l csharp && mv *.*.md docs`;
 
     // Special overwrite for some very special resources
     if (providerName === "aws") {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1338,7 +1338,7 @@ cdktf.json
       \\"description\\": \\"Generate API.md from .jsii manifest\\",
       \\"steps\\": [
         {
-          \\"exec\\": \\"rm -rf docs && mkdir docs && jsii-docgen --split-by-submodule -l typescript -l python -l java -l csharp -l go && mv *.*.md docs\\"
+          \\"exec\\": \\"rm -rf docs && mkdir docs && jsii-docgen --split-by-submodule -l typescript -l python -l java -l csharp && mv *.*.md docs\\"
         }
       ]
     },
@@ -3849,7 +3849,7 @@ cdktf.json
       \\"description\\": \\"Generate API.md from .jsii manifest\\",
       \\"steps\\": [
         {
-          \\"exec\\": \\"rm -rf docs && mkdir docs && jsii-docgen --split-by-submodule -l typescript -l python -l java -l csharp -l go && mv *.*.md docs\\"
+          \\"exec\\": \\"rm -rf docs && mkdir docs && jsii-docgen --split-by-submodule -l typescript -l python -l java -l csharp && mv *.*.md docs\\"
         }
       ]
     },
@@ -6315,7 +6315,7 @@ cdktf.json
       \\"description\\": \\"Generate API.md from .jsii manifest\\",
       \\"steps\\": [
         {
-          \\"exec\\": \\"rm -rf docs && mkdir docs && jsii-docgen --split-by-submodule -l typescript -l python -l java -l csharp -l go && mv *.*.md docs\\"
+          \\"exec\\": \\"rm -rf docs && mkdir docs && jsii-docgen --split-by-submodule -l typescript -l python -l java -l csharp && mv *.*.md docs\\"
         }
       ]
     },


### PR DESCRIPTION
https://github.com/projen/projen/pull/2472 should allow us to fix the issue of changing documentation during release permanently, this is a temporary fix until the projen PR is merged and released

Fixes #