### PR TITLE
fix: ignore docs/ and API.md for NPM packages

### DIFF
--- a/src/cdktf-config.ts
+++ b/src/cdktf-config.ts
@@ -135,6 +135,8 @@ export class CdktfConfig {
       project.npmignore.exclude(".gen");
       project.npmignore.exclude(".terraform");
       project.npmignore.exclude("cdktf.json");
+      project.npmignore.exclude("API.md");
+      project.npmignore.exclude("docs");
     }
     project.gitignore.exclude(".gen");
     project.gitignore.exclude(".terraform");

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1080,6 +1080,8 @@ tsconfig.tsbuildinfo
 .gen
 .terraform
 cdktf.json
+API.md
+docs
 ",
   ".projen/deps.json": "{
   \\"dependencies\\": [
@@ -3605,6 +3607,8 @@ tsconfig.tsbuildinfo
 .gen
 .terraform
 cdktf.json
+API.md
+docs
 ",
   ".projen/deps.json": "{
   \\"dependencies\\": [
@@ -6085,6 +6089,8 @@ tsconfig.tsbuildinfo
 .gen
 .terraform
 cdktf.json
+API.md
+docs
 ",
   ".projen/deps.json": "{
   \\"dependencies\\": [


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-cdk/issues/2829
