### PR TITLE
fix: Use 'env' instead of 'environment' to fix github action

### DIFF
--- a/src/provider-upgrade.ts
+++ b/src/provider-upgrade.ts
@@ -40,7 +40,7 @@ export class ProviderUpgrade {
     workflow.addJobs({
       upgrade: {
         runsOn: options.workflowRunsOn,
-        environment: {
+        env: {
           NODE_OPTIONS: `--max-old-space-size=${options.nodeHeapSize}`,
         },
         steps: [


### PR DESCRIPTION
Fixes invalid yaml generated by #321 