### PR TITLE
fix: close empty PRs instead of merging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,23 @@ export class CdktfProviderProject extends cdk.JsiiProject {
                 },
               },
               conditions: [
+                "#files!=0",
+                "label=automerge",
+                "-label~=(do-not-merge)",
+                "-draft",
+                "author=team-tf-cdk",
+              ],
+            },
+            {
+              name: "Close PRs with no changes",
+              actions: {
+                close: {
+                  message:
+                    "Closing this automatic PR because there are no changes to merge",
+                },
+              },
+              conditions: [
+                "#files=0",
                 "label=automerge",
                 "-label~=(do-not-merge)",
                 "-draft",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1063,6 +1063,17 @@ pull_request_rules:
         type: APPROVE
         message: Automatically approved due to label
     conditions:
+      - \\"#files!=0\\"
+      - label=automerge
+      - -label~=(do-not-merge)
+      - -draft
+      - author=team-tf-cdk
+  - name: Close PRs with no changes
+    actions:
+      close:
+        message: Closing this automatic PR because there are no changes to merge
+    conditions:
+      - \\"#files=0\\"
       - label=automerge
       - -label~=(do-not-merge)
       - -draft
@@ -3645,6 +3656,17 @@ pull_request_rules:
         type: APPROVE
         message: Automatically approved due to label
     conditions:
+      - \\"#files!=0\\"
+      - label=automerge
+      - -label~=(do-not-merge)
+      - -draft
+      - author=team-tf-cdk
+  - name: Close PRs with no changes
+    actions:
+      close:
+        message: Closing this automatic PR because there are no changes to merge
+    conditions:
+      - \\"#files=0\\"
       - label=automerge
       - -label~=(do-not-merge)
       - -draft
@@ -6182,6 +6204,17 @@ pull_request_rules:
         type: APPROVE
         message: Automatically approved due to label
     conditions:
+      - \\"#files!=0\\"
+      - label=automerge
+      - -label~=(do-not-merge)
+      - -draft
+      - author=team-tf-cdk
+  - name: Close PRs with no changes
+    actions:
+      close:
+        message: Closing this automatic PR because there are no changes to merge
+    conditions:
+      - \\"#files=0\\"
       - label=automerge
       - -label~=(do-not-merge)
       - -draft


### PR DESCRIPTION
I noticed today that our automations create a lot of empty PRs like https://github.com/cdktf/cdktf-provider-ad/pull/297 (because Projen undoes all the changes in the original PR). It'd be nice to close those instead of merging them to keep the changelogs cleaner.
