### PR TITLE
fix: set min major version for unconditional bump

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,9 @@ import { ProviderUpgrade } from "./provider-upgrade";
 import { CheckForUpgradesScriptFile } from "./scripts/check-for-upgrades";
 import { ShouldReleaseScriptFile } from "./scripts/should-release";
 
+// ensure new projects start with 1.0.0 so that every following breaking change leads to an increased major version
+const MIN_MAJOR_VERSION = 1;
+
 export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
   readonly useCustomGithubRunner?: boolean;
   readonly terraformProvider: string;
@@ -187,7 +190,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
         email: "github-team-tf-cdk@hashicorp.com",
       },
       workflowRunsOn,
-      minMajorVersion: 1, // ensure new projects start with 1.0.0 so that every following breaking change leads to an increased major version
+      minMajorVersion: MIN_MAJOR_VERSION,
       githubOptions: {
         mergify: true,
         mergifyOptions: {
@@ -396,6 +399,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
         BUMPFILE: "dist/version.txt",
         RELEASETAG: "dist/releasetag.txt",
         RELEASE_TAG_PREFIX: "",
+        MIN_MAJOR: String(MIN_MAJOR_VERSION),
       },
     });
     this.preCompileTask.spawn(unconditionalBump);

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1580,7 +1580,8 @@ docs
         \\"CHANGELOG\\": \\"dist/changelog.md\\",
         \\"BUMPFILE\\": \\"dist/version.txt\\",
         \\"RELEASETAG\\": \\"dist/releasetag.txt\\",
-        \\"RELEASE_TAG_PREFIX\\": \\"\\"
+        \\"RELEASE_TAG_PREFIX\\": \\"\\",
+        \\"MIN_MAJOR\\": \\"1\\"
       },
       \\"steps\\": [
         {
@@ -4162,7 +4163,8 @@ docs
         \\"CHANGELOG\\": \\"dist/changelog.md\\",
         \\"BUMPFILE\\": \\"dist/version.txt\\",
         \\"RELEASETAG\\": \\"dist/releasetag.txt\\",
-        \\"RELEASE_TAG_PREFIX\\": \\"\\"
+        \\"RELEASE_TAG_PREFIX\\": \\"\\",
+        \\"MIN_MAJOR\\": \\"1\\"
       },
       \\"steps\\": [
         {
@@ -6699,7 +6701,8 @@ docs
         \\"CHANGELOG\\": \\"dist/changelog.md\\",
         \\"BUMPFILE\\": \\"dist/version.txt\\",
         \\"RELEASETAG\\": \\"dist/releasetag.txt\\",
-        \\"RELEASE_TAG_PREFIX\\": \\"\\"
+        \\"RELEASE_TAG_PREFIX\\": \\"\\",
+        \\"MIN_MAJOR\\": \\"1\\"
       },
       \\"steps\\": [
         {


### PR DESCRIPTION
we shadow projens built-in bump with our unconditional one, so we need to apply the min major version there
