### PR TITLE
chore: fix upgrade-main workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16.13.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16.13.0
+          node-version: 16.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16.13.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16.13.0
+          node-version: 16.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16.13.0
+          node-version: 16.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: 16.13.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -4,6 +4,7 @@
  */
 
 import { cdk } from "projen";
+import { UpgradeDependenciesSchedule } from "projen/lib/javascript";
 import { CustomizedLicense } from "./src/customized-license";
 import { LockIssues } from "./src/lock-issues";
 
@@ -32,7 +33,7 @@ const project = new cdk.JsiiProject({
   license: "MPL-2.0",
   defaultReleaseBranch: "main",
   releaseToNpm: true,
-  minNodeVersion: "16.13.0",
+  minNodeVersion: "16.14.0",
   mergify: false,
   scripts: {
     "eslint:fix": "eslint . --ext .ts --fix",
@@ -41,6 +42,7 @@ const project = new cdk.JsiiProject({
   depsUpgradeOptions: {
     workflowOptions: {
       labels: ["dependencies"],
+      schedule: UpgradeDependenciesSchedule.WEEKLY,
     },
   },
   workflowGitIdentity: {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/babel__traverse": "7.18.2"
   },
   "engines": {
-    "node": ">= 16.13.0"
+    "node": ">= 16.14.0"
   },
   "main": "lib/index.js",
   "license": "MPL-2.0",


### PR DESCRIPTION
This workflow hasn't been running for a couple of months now:   https://github.com/cdktf/cdktf-provider-project/actions/runs/5663099812/job/15344250645

I figure we can also change the upgrade schedule to weekly because we really don't need nightly Projen upgrades.