### PR TITLE
chore: upgrade dependencies for providers weekly instead of nightly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import assert = require("assert");
 import { pascalCase } from "change-case";
 import { TextFile, cdk, github, JsonPatch } from "projen";
 import { JobStep } from "projen/lib/github/workflows-model";
+import { UpgradeDependenciesSchedule } from "projen/lib/javascript";
 import { AlertOpenPrs } from "./alert-open-prs";
 import { AutoCloseCommunityIssues } from "./auto-close-community-issues";
 import { CdktfConfig } from "./cdktf-config";
@@ -175,6 +176,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       depsUpgradeOptions: {
         workflowOptions: {
           labels: ["automerge", "dependencies"],
+          schedule: UpgradeDependenciesSchedule.WEEKLY,
         },
       },
       python: packageInfo.python,

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -889,7 +889,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -3472,7 +3472,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade
@@ -6010,7 +6010,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade


### PR DESCRIPTION
This can help cut down on the GitHub notification spam as well as the excessive Mergify usage. Most of the time, Projen is the only thing that gets updated anyway, and we really don't need those updates nightly.

The downside is that this also updates CDKTF patch versions, but if we ever critically need to update all providers with a patch, I suppose we could just trigger it manually from cdktf-repository-manager.