### PR TITLE
feat: Add underlying provider version to readme

### DIFF
--- a/src/cdktf-config.ts
+++ b/src/cdktf-config.ts
@@ -24,7 +24,6 @@ interface CdktfConfigOptions {
 }
 
 export class CdktfConfig {
-  public underlyingTerraformProviderVersion: string;
   constructor(project: cdk.JsiiProject, options: CdktfConfigOptions) {
     const { terraformProvider, providerName, jsiiVersion } = options;
 
@@ -127,8 +126,6 @@ export class CdktfConfig {
       fullyQualifiedProviderName = fqpn;
       actualProviderVersion = version as string;
     }
-
-    this.underlyingTerraformProviderVersion = actualProviderVersion;
 
     project.addFields({
       cdktf: {

--- a/src/cdktf-config.ts
+++ b/src/cdktf-config.ts
@@ -24,6 +24,7 @@ interface CdktfConfigOptions {
 }
 
 export class CdktfConfig {
+  public underlyingTerraformProviderVersion: string;
   constructor(project: cdk.JsiiProject, options: CdktfConfigOptions) {
     const { terraformProvider, providerName, jsiiVersion } = options;
 
@@ -127,6 +128,8 @@ export class CdktfConfig {
       actualProviderVersion = version as string;
     }
 
+    this.underlyingTerraformProviderVersion = actualProviderVersion;
+
     project.addFields({
       cdktf: {
         provider: {
@@ -157,6 +160,9 @@ export class CdktfConfig {
       },
     });
 
-    new ReadmeFile(project, "README.md", options);
+    new ReadmeFile(project, "README.md", {
+      ...options,
+      underlyingTerraformVersion: actualProviderVersion,
+    });
   }
 }

--- a/src/readme.ts
+++ b/src/readme.ts
@@ -11,6 +11,7 @@ export interface ReadmeFileOptions extends FileBaseOptions {
   fqproviderName: string;
   providerVersion: string;
   packageInfo: PackageInfo;
+  underlyingTerraformVersion: string;
 }
 
 export class ReadmeFile extends FileBase {
@@ -22,8 +23,13 @@ export class ReadmeFile extends FileBase {
   }
 
   protected synthesizeContent(resolver: IResolver) {
-    const { providerName, fqproviderName, providerVersion, packageInfo } =
-      resolver.resolve(this.options) as ReadmeFileOptions;
+    const {
+      providerName,
+      fqproviderName,
+      providerVersion,
+      packageInfo,
+      underlyingTerraformVersion,
+    } = resolver.resolve(this.options) as ReadmeFileOptions;
 
     const fqpnURL = fqproviderName.includes("/")
       ? fqproviderName
@@ -33,7 +39,11 @@ export class ReadmeFile extends FileBase {
       : "";
 
     return `
-# Terraform CDK ${providerName} Provider ${providerVersion}
+# Terraform CDK ${providerName} Provider ${
+      underlyingTerraformVersion !== "<unknown>"
+        ? underlyingTerraformVersion
+        : ""
+    } tracks ${providerVersion}
 
 This repo builds and publishes the Terraform ${providerName} Provider bindings for [CDK for Terraform](https://cdk.tf).
 
@@ -41,25 +51,37 @@ This repo builds and publishes the Terraform ${providerName} Provider bindings f
 
 ### NPM
 
-The npm package is available at [https://www.npmjs.com/package/${packageInfo.npm.name}](https://www.npmjs.com/package/${packageInfo.npm.name}).
+The npm package is available at [https://www.npmjs.com/package/${
+      packageInfo.npm.name
+    }](https://www.npmjs.com/package/${packageInfo.npm.name}).
 
 \`npm install ${packageInfo.npm.name}\`
 
 ### PyPI
 
-The PyPI package is available at [https://pypi.org/project/${packageInfo.python.distName}](https://pypi.org/project/${packageInfo.python.distName}).
+The PyPI package is available at [https://pypi.org/project/${
+      packageInfo.python.distName
+    }](https://pypi.org/project/${packageInfo.python.distName}).
 
 \`pipenv install ${packageInfo.python.distName}\`
 
 ### Nuget
 
-The Nuget package is available at [https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId}](https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId}).
+The Nuget package is available at [https://www.nuget.org/packages/${
+      packageInfo.publishToNuget.packageId
+    }](https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId}).
 
 \`dotnet add package ${packageInfo.publishToNuget.packageId}\`
 
 ### Maven
 
-The Maven package is available at [https://mvnrepository.com/artifact/${packageInfo.publishToMaven.mavenGroupId}/${packageInfo.publishToMaven.mavenArtifactId}](https://mvnrepository.com/artifact/${packageInfo.publishToMaven.mavenGroupId}/${packageInfo.publishToMaven.mavenArtifactId}).
+The Maven package is available at [https://mvnrepository.com/artifact/${
+      packageInfo.publishToMaven.mavenGroupId
+    }/${
+      packageInfo.publishToMaven.mavenArtifactId
+    }](https://mvnrepository.com/artifact/${
+      packageInfo.publishToMaven.mavenGroupId
+    }/${packageInfo.publishToMaven.mavenArtifactId}).
 
 \`\`\`
 <dependency>
@@ -72,9 +94,13 @@ The Maven package is available at [https://mvnrepository.com/artifact/${packageI
 
 ### Go
 
-The go package is generated into the [\`${packageInfo.publishToGo?.moduleName}\`](https://${packageInfo.publishToGo?.moduleName}) package.
+The go package is generated into the [\`${
+      packageInfo.publishToGo?.moduleName
+    }\`](https://${packageInfo.publishToGo?.moduleName}) package.
 
-\`go get ${packageInfo.publishToGo?.moduleName}/${packageInfo.publishToGo?.packageName}\`
+\`go get ${packageInfo.publishToGo?.moduleName}/${
+      packageInfo.publishToGo?.packageName
+    }\`
 
 ## Docs
 

--- a/src/readme.ts
+++ b/src/readme.ts
@@ -39,49 +39,44 @@ export class ReadmeFile extends FileBase {
       : "";
 
     return `
-# Terraform CDK ${providerName} Provider ${
-      underlyingTerraformVersion !== "<unknown>"
-        ? underlyingTerraformVersion
-        : ""
-    } tracks ${providerVersion}
+# Terraform CDK ${providerName} Provider tracks ${providerVersion}
 
 This repo builds and publishes the Terraform ${providerName} Provider bindings for [CDK for Terraform](https://cdk.tf).
+
+${underlyingTerraformVersion !== "<unknown>"
+        ? `Is based directly on ${providerName} ${underlyingTerraformVersion}`
+        : ''
+      }
 
 ## Available Packages
 
 ### NPM
 
-The npm package is available at [https://www.npmjs.com/package/${
-      packageInfo.npm.name
-    }](https://www.npmjs.com/package/${packageInfo.npm.name}).
+The npm package is available at [https://www.npmjs.com/package/${packageInfo.npm.name
+      }](https://www.npmjs.com/package/${packageInfo.npm.name}).
 
 \`npm install ${packageInfo.npm.name}\`
 
 ### PyPI
 
-The PyPI package is available at [https://pypi.org/project/${
-      packageInfo.python.distName
-    }](https://pypi.org/project/${packageInfo.python.distName}).
+The PyPI package is available at [https://pypi.org/project/${packageInfo.python.distName
+      }](https://pypi.org/project/${packageInfo.python.distName}).
 
 \`pipenv install ${packageInfo.python.distName}\`
 
 ### Nuget
 
-The Nuget package is available at [https://www.nuget.org/packages/${
-      packageInfo.publishToNuget.packageId
-    }](https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId}).
+The Nuget package is available at [https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId
+      }](https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId}).
 
 \`dotnet add package ${packageInfo.publishToNuget.packageId}\`
 
 ### Maven
 
-The Maven package is available at [https://mvnrepository.com/artifact/${
-      packageInfo.publishToMaven.mavenGroupId
-    }/${
-      packageInfo.publishToMaven.mavenArtifactId
-    }](https://mvnrepository.com/artifact/${
-      packageInfo.publishToMaven.mavenGroupId
-    }/${packageInfo.publishToMaven.mavenArtifactId}).
+The Maven package is available at [https://mvnrepository.com/artifact/${packageInfo.publishToMaven.mavenGroupId
+      }/${packageInfo.publishToMaven.mavenArtifactId
+      }](https://mvnrepository.com/artifact/${packageInfo.publishToMaven.mavenGroupId
+      }/${packageInfo.publishToMaven.mavenArtifactId}).
 
 \`\`\`
 <dependency>
@@ -94,13 +89,11 @@ The Maven package is available at [https://mvnrepository.com/artifact/${
 
 ### Go
 
-The go package is generated into the [\`${
-      packageInfo.publishToGo?.moduleName
-    }\`](https://${packageInfo.publishToGo?.moduleName}) package.
+The go package is generated into the [\`${packageInfo.publishToGo?.moduleName
+      }\`](https://${packageInfo.publishToGo?.moduleName}) package.
 
-\`go get ${packageInfo.publishToGo?.moduleName}/${
-      packageInfo.publishToGo?.packageName
-    }\`
+\`go get ${packageInfo.publishToGo?.moduleName}/${packageInfo.publishToGo?.packageName
+      }\`
 
 ## Docs
 
@@ -121,7 +114,7 @@ This project is explicitly not tracking the Terraform ${providerName} Provider v
 These are the upstream dependencies:
 
 - [Terraform CDK](https://cdk.tf)
-- [Terraform ${providerName} Provider](https://registry.terraform.io/providers/${fqpnURL}/${versionURL})
+- [Terraform ${providerName} Provider](https://registry.terraform.io/providers/${fqpnURL}/${underlyingTerraformVersion !== "<unknown>" ? underlyingTerraformVersion : versionURL})
     - This links to the minimum version being tracked, you can find the latest released version [in our releases](https://github.com/cdktf/cdktf-provider-${providerName}/releases)
 - [Terraform Engine](https://terraform.io)
 

--- a/src/readme.ts
+++ b/src/readme.ts
@@ -43,40 +43,47 @@ export class ReadmeFile extends FileBase {
 
 This repo builds and publishes the Terraform ${providerName} Provider bindings for [CDK for Terraform](https://cdk.tf).
 
-${underlyingTerraformVersion !== "<unknown>"
-        ? `Is based directly on ${providerName} ${underlyingTerraformVersion}`
-        : ''
-      }
+${
+  underlyingTerraformVersion !== "<unknown>"
+    ? `Is based directly on ${providerName} ${underlyingTerraformVersion}`
+    : ""
+}
 
 ## Available Packages
 
 ### NPM
 
-The npm package is available at [https://www.npmjs.com/package/${packageInfo.npm.name
-      }](https://www.npmjs.com/package/${packageInfo.npm.name}).
+The npm package is available at [https://www.npmjs.com/package/${
+      packageInfo.npm.name
+    }](https://www.npmjs.com/package/${packageInfo.npm.name}).
 
 \`npm install ${packageInfo.npm.name}\`
 
 ### PyPI
 
-The PyPI package is available at [https://pypi.org/project/${packageInfo.python.distName
-      }](https://pypi.org/project/${packageInfo.python.distName}).
+The PyPI package is available at [https://pypi.org/project/${
+      packageInfo.python.distName
+    }](https://pypi.org/project/${packageInfo.python.distName}).
 
 \`pipenv install ${packageInfo.python.distName}\`
 
 ### Nuget
 
-The Nuget package is available at [https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId
-      }](https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId}).
+The Nuget package is available at [https://www.nuget.org/packages/${
+      packageInfo.publishToNuget.packageId
+    }](https://www.nuget.org/packages/${packageInfo.publishToNuget.packageId}).
 
 \`dotnet add package ${packageInfo.publishToNuget.packageId}\`
 
 ### Maven
 
-The Maven package is available at [https://mvnrepository.com/artifact/${packageInfo.publishToMaven.mavenGroupId
-      }/${packageInfo.publishToMaven.mavenArtifactId
-      }](https://mvnrepository.com/artifact/${packageInfo.publishToMaven.mavenGroupId
-      }/${packageInfo.publishToMaven.mavenArtifactId}).
+The Maven package is available at [https://mvnrepository.com/artifact/${
+      packageInfo.publishToMaven.mavenGroupId
+    }/${
+      packageInfo.publishToMaven.mavenArtifactId
+    }](https://mvnrepository.com/artifact/${
+      packageInfo.publishToMaven.mavenGroupId
+    }/${packageInfo.publishToMaven.mavenArtifactId}).
 
 \`\`\`
 <dependency>
@@ -89,11 +96,13 @@ The Maven package is available at [https://mvnrepository.com/artifact/${packageI
 
 ### Go
 
-The go package is generated into the [\`${packageInfo.publishToGo?.moduleName
-      }\`](https://${packageInfo.publishToGo?.moduleName}) package.
+The go package is generated into the [\`${
+      packageInfo.publishToGo?.moduleName
+    }\`](https://${packageInfo.publishToGo?.moduleName}) package.
 
-\`go get ${packageInfo.publishToGo?.moduleName}/${packageInfo.publishToGo?.packageName
-      }\`
+\`go get ${packageInfo.publishToGo?.moduleName}/${
+      packageInfo.publishToGo?.packageName
+    }\`
 
 ## Docs
 
@@ -114,7 +123,11 @@ This project is explicitly not tracking the Terraform ${providerName} Provider v
 These are the upstream dependencies:
 
 - [Terraform CDK](https://cdk.tf)
-- [Terraform ${providerName} Provider](https://registry.terraform.io/providers/${fqpnURL}/${underlyingTerraformVersion !== "<unknown>" ? underlyingTerraformVersion : versionURL})
+- [Terraform ${providerName} Provider](https://registry.terraform.io/providers/${fqpnURL}/${
+      underlyingTerraformVersion !== "<unknown>"
+        ? underlyingTerraformVersion
+        : versionURL
+    })
     - This links to the minimum version being tracked, you can find the latest released version [in our releases](https://github.com/cdktf/cdktf-provider-${providerName}/releases)
 - [Terraform Engine](https://terraform.io)
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2003,9 +2003,11 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider  tracks undefined
+# Terraform CDK random Provider tracks undefined
 
 This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
+
+
 
 ## Available Packages
 
@@ -4586,9 +4588,11 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider  tracks undefined
+# Terraform CDK random Provider tracks undefined
 
 This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
+
+
 
 ## Available Packages
 
@@ -7124,9 +7128,11 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider  tracks undefined
+# Terraform CDK random Provider tracks undefined
 
 This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
+
+
 
 ## Available Packages
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2003,7 +2003,7 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider undefined
+# Terraform CDK random Provider  tracks undefined
 
 This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
 
@@ -4586,7 +4586,7 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider undefined
+# Terraform CDK random Provider  tracks undefined
 
 This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
 
@@ -7124,7 +7124,7 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider undefined
+# Terraform CDK random Provider  tracks undefined
 
 This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-cdk/issues/2680

Includes underlying provider version in README as read from `src/version.json`.

Side benefit of this is using the actual underlying provider version to build the link to the terraform registry, instead of an approximate version as before.

Found there to be some ambiguity around when/if `src/version.json` would be present as  you can see here:
```typescript
    // set provider name and version from version.json (if it exists yet)
    const versionFile = path.resolve(project.outdir, "src/version.json");

    let fullyQualifiedProviderName = "<unknown>";
    let actualProviderVersion = "<unknown>";
    if (existsSync(versionFile)) {
      const map = JSON.parse(readFileSync(versionFile, "utf8"));
      if (Object.keys(map).length !== 1) {
        throw new Error(
          "version.json must have exactly one entry. specifying multiple providers is not supported"
        );
      }
      const [fqpn, version] = Object.entries(map)[0];
      fullyQualifiedProviderName = fqpn;
      actualProviderVersion = version as string;
    }
```

As such I've made sure to default to the current state of the README is the event it isn't present.