### PR TITLE
fix: Everything resides in .repo, fix source path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
           },
           {
             name: "Copy copywrite hcl file",
-            run: "cp .copywrite.hcl .repo/dist/go/.copywrite.hcl",
+            run: "cp .repo/.copywrite.hcl .repo/dist/go/.copywrite.hcl",
           },
           {
             name: "Add headers using Copywrite tool",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -833,7 +833,7 @@ jobs:
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e
       - name: Copy copywrite hcl file
-        run: cp .copywrite.hcl .repo/dist/go/.copywrite.hcl
+        run: cp .repo/.copywrite.hcl .repo/dist/go/.copywrite.hcl
       - name: Add headers using Copywrite tool
         run: cd .repo/dist/go && copywrite headers
       - name: Remove copywrite hcl file
@@ -3424,7 +3424,7 @@ jobs:
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e
       - name: Copy copywrite hcl file
-        run: cp .copywrite.hcl .repo/dist/go/.copywrite.hcl
+        run: cp .repo/.copywrite.hcl .repo/dist/go/.copywrite.hcl
       - name: Add headers using Copywrite tool
         run: cd .repo/dist/go && copywrite headers
       - name: Remove copywrite hcl file
@@ -5970,7 +5970,7 @@ jobs:
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e
       - name: Copy copywrite hcl file
-        run: cp .copywrite.hcl .repo/dist/go/.copywrite.hcl
+        run: cp .repo/.copywrite.hcl .repo/dist/go/.copywrite.hcl
       - name: Add headers using Copywrite tool
         run: cd .repo/dist/go && copywrite headers
       - name: Remove copywrite hcl file


### PR DESCRIPTION
Fixes issues with go releases being blocked on prebuilt providers