### PR TITLE
chore(docs): improve READMEs for individual providers

### DIFF
--- a/src/readme.ts
+++ b/src/readme.ts
@@ -49,7 +49,7 @@ This repo builds and publishes the [Terraform ${providerName} provider](https://
       underlyingTerraformVersion !== "<unknown>"
         ? underlyingTerraformVersion
         : versionURL
-    }) bindings for [CDK for Terraform](https://cdk.tf).
+    }/docs) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 

--- a/src/readme.ts
+++ b/src/readme.ts
@@ -39,15 +39,17 @@ export class ReadmeFile extends FileBase {
       : "";
 
     return `
-# Terraform CDK ${providerName} Provider tracks ${providerVersion}
+# CDKTF prebuilt bindings for ${fqpnURL} provider version ${
+      underlyingTerraformVersion !== "<unknown>"
+        ? `${underlyingTerraformVersion}`
+        : `${providerVersion}`
+    }
 
-This repo builds and publishes the Terraform ${providerName} Provider bindings for [CDK for Terraform](https://cdk.tf).
-
-${
-  underlyingTerraformVersion !== "<unknown>"
-    ? `Is based directly on ${providerName} ${underlyingTerraformVersion}`
-    : ""
-}
+This repo builds and publishes the [Terraform ${providerName} provider](https://registry.terraform.io/providers/${fqpnURL}/${
+      underlyingTerraformVersion !== "<unknown>"
+        ? underlyingTerraformVersion
+        : versionURL
+    }) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 
@@ -118,37 +120,36 @@ You can also visit a hosted version of the documentation on [constructs.dev](htt
 
 ## Versioning
 
-This project is explicitly not tracking the Terraform ${providerName} Provider version 1:1. In fact, it always tracks \`latest\` of \`${providerVersion}\` with every release. If there are scenarios where you explicitly have to pin your provider version, you can do so by generating the [provider constructs manually](https://cdk.tf/imports).
+This project is explicitly not tracking the Terraform ${providerName} provider version 1:1. In fact, it always tracks \`latest\` of \`${providerVersion}\` with every release. If there are scenarios where you explicitly have to pin your provider version, you can do so by [generating the provider constructs manually](https://cdk.tf/imports).
 
 These are the upstream dependencies:
 
-- [Terraform CDK](https://cdk.tf)
-- [Terraform ${providerName} Provider](https://registry.terraform.io/providers/${fqpnURL}/${
+- [CDK for Terraform](https://cdk.tf)
+- [Terraform ${providerName} provider](https://registry.terraform.io/providers/${fqpnURL}/${
       underlyingTerraformVersion !== "<unknown>"
         ? underlyingTerraformVersion
         : versionURL
     })
-    - This links to the minimum version being tracked, you can find the latest released version [in our releases](https://github.com/cdktf/cdktf-provider-${providerName}/releases)
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.
 
 ## Features / Issues / Bugs
 
-Please report bugs and issues to the [terraform cdk](https://cdk.tf) project:
+Please report bugs and issues to the [CDK for Terraform](https://cdk.tf) project:
 
 - [Create bug report](https://cdk.tf/bug)
 - [Create feature request](https://cdk.tf/feature)
 
 ## Contributing
 
-### projen
+### Projen
 
-This is mostly based on [projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
+This is mostly based on [Projen](https://github.com/projen/projen), which takes care of generating the entire repository.
 
-### cdktf-provider-project based on projen
+### cdktf-provider-project based on Projen
 
-There's a custom [project builder](https://github.com/hashicorp/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` providers.
+There's a custom [project builder](https://github.com/cdktf/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` prebuilt providers.
 
 ### Provider Version
 
@@ -156,7 +157,7 @@ The provider version can be adjusted in [./.projenrc.js](./.projenrc.js).
 
 ### Repository Management
 
-The repository is managed by [Repository Manager](https://github.com/hashicorp/cdktf-repository-manager/)
+The repository is managed by [CDKTF Repository Manager](https://github.com/cdktf/cdktf-repository-manager/).
 `;
   }
 }

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2146,7 +2146,7 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
   "README.md": "
 # CDKTF prebuilt bindings for hashicorp/random provider version ~>2.0
 
-This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0) bindings for [CDK for Terraform](https://cdk.tf).
+This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0/docs) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 
@@ -2222,7 +2222,7 @@ Please report bugs and issues to the [CDK for Terraform](https://cdk.tf) project
 
 ### Projen
 
-This is mostly based on [Projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
+This is mostly based on [Projen](https://github.com/projen/projen), which takes care of generating the entire repository.
 
 ### cdktf-provider-project based on Projen
 
@@ -4872,7 +4872,7 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
   "README.md": "
 # CDKTF prebuilt bindings for hashicorp/random provider version ~>2.0
 
-This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0) bindings for [CDK for Terraform](https://cdk.tf).
+This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0/docs) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 
@@ -4948,7 +4948,7 @@ Please report bugs and issues to the [CDK for Terraform](https://cdk.tf) project
 
 ### Projen
 
-This is mostly based on [Projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
+This is mostly based on [Projen](https://github.com/projen/projen), which takes care of generating the entire repository.
 
 ### cdktf-provider-project based on Projen
 
@@ -7547,7 +7547,7 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
   "README.md": "
 # CDKTF prebuilt bindings for hashicorp/random provider version ~>2.0
 
-This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0) bindings for [CDK for Terraform](https://cdk.tf).
+This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0/docs) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 
@@ -7623,7 +7623,7 @@ Please report bugs and issues to the [CDK for Terraform](https://cdk.tf) project
 
 ### Projen
 
-This is mostly based on [Projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
+This is mostly based on [Projen](https://github.com/projen/projen), which takes care of generating the entire repository.
 
 ### cdktf-provider-project based on Projen
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2144,11 +2144,9 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider tracks ~>2.0
+# CDKTF prebuilt bindings for hashicorp/random provider version ~>2.0
 
-This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
-
-
+This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 
@@ -2203,33 +2201,32 @@ You can also visit a hosted version of the documentation on [constructs.dev](htt
 
 ## Versioning
 
-This project is explicitly not tracking the Terraform random Provider version 1:1. In fact, it always tracks \`latest\` of \`~>2.0\` with every release. If there are scenarios where you explicitly have to pin your provider version, you can do so by generating the [provider constructs manually](https://cdk.tf/imports).
+This project is explicitly not tracking the Terraform random provider version 1:1. In fact, it always tracks \`latest\` of \`~>2.0\` with every release. If there are scenarios where you explicitly have to pin your provider version, you can do so by [generating the provider constructs manually](https://cdk.tf/imports).
 
 These are the upstream dependencies:
 
-- [Terraform CDK](https://cdk.tf)
-- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0)
-    - This links to the minimum version being tracked, you can find the latest released version [in our releases](https://github.com/cdktf/cdktf-provider-random/releases)
+- [CDK for Terraform](https://cdk.tf)
+- [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0)
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.
 
 ## Features / Issues / Bugs
 
-Please report bugs and issues to the [terraform cdk](https://cdk.tf) project:
+Please report bugs and issues to the [CDK for Terraform](https://cdk.tf) project:
 
 - [Create bug report](https://cdk.tf/bug)
 - [Create feature request](https://cdk.tf/feature)
 
 ## Contributing
 
-### projen
+### Projen
 
-This is mostly based on [projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
+This is mostly based on [Projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
 
-### cdktf-provider-project based on projen
+### cdktf-provider-project based on Projen
 
-There's a custom [project builder](https://github.com/hashicorp/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` providers.
+There's a custom [project builder](https://github.com/cdktf/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` prebuilt providers.
 
 ### Provider Version
 
@@ -2237,7 +2234,7 @@ The provider version can be adjusted in [./.projenrc.js](./.projenrc.js).
 
 ### Repository Management
 
-The repository is managed by [Repository Manager](https://github.com/hashicorp/cdktf-repository-manager/)
+The repository is managed by [CDKTF Repository Manager](https://github.com/cdktf/cdktf-repository-manager/).
 ",
   "cdktf.json": "{
   "language": "typescript",
@@ -4873,11 +4870,9 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider tracks ~>2.0
+# CDKTF prebuilt bindings for hashicorp/random provider version ~>2.0
 
-This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
-
-
+This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 
@@ -4932,33 +4927,32 @@ You can also visit a hosted version of the documentation on [constructs.dev](htt
 
 ## Versioning
 
-This project is explicitly not tracking the Terraform random Provider version 1:1. In fact, it always tracks \`latest\` of \`~>2.0\` with every release. If there are scenarios where you explicitly have to pin your provider version, you can do so by generating the [provider constructs manually](https://cdk.tf/imports).
+This project is explicitly not tracking the Terraform random provider version 1:1. In fact, it always tracks \`latest\` of \`~>2.0\` with every release. If there are scenarios where you explicitly have to pin your provider version, you can do so by [generating the provider constructs manually](https://cdk.tf/imports).
 
 These are the upstream dependencies:
 
-- [Terraform CDK](https://cdk.tf)
-- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0)
-    - This links to the minimum version being tracked, you can find the latest released version [in our releases](https://github.com/cdktf/cdktf-provider-random/releases)
+- [CDK for Terraform](https://cdk.tf)
+- [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0)
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.
 
 ## Features / Issues / Bugs
 
-Please report bugs and issues to the [terraform cdk](https://cdk.tf) project:
+Please report bugs and issues to the [CDK for Terraform](https://cdk.tf) project:
 
 - [Create bug report](https://cdk.tf/bug)
 - [Create feature request](https://cdk.tf/feature)
 
 ## Contributing
 
-### projen
+### Projen
 
-This is mostly based on [projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
+This is mostly based on [Projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
 
-### cdktf-provider-project based on projen
+### cdktf-provider-project based on Projen
 
-There's a custom [project builder](https://github.com/hashicorp/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` providers.
+There's a custom [project builder](https://github.com/cdktf/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` prebuilt providers.
 
 ### Provider Version
 
@@ -4966,7 +4960,7 @@ The provider version can be adjusted in [./.projenrc.js](./.projenrc.js).
 
 ### Repository Management
 
-The repository is managed by [Repository Manager](https://github.com/hashicorp/cdktf-repository-manager/)
+The repository is managed by [CDKTF Repository Manager](https://github.com/cdktf/cdktf-repository-manager/).
 ",
   "cdktf.json": "{
   "language": "typescript",
@@ -7551,11 +7545,9 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
       the Mozilla Public License, v. 2.0.
 ",
   "README.md": "
-# Terraform CDK random Provider tracks ~>2.0
+# CDKTF prebuilt bindings for hashicorp/random provider version ~>2.0
 
-This repo builds and publishes the Terraform random Provider bindings for [CDK for Terraform](https://cdk.tf).
-
-
+This repo builds and publishes the [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0) bindings for [CDK for Terraform](https://cdk.tf).
 
 ## Available Packages
 
@@ -7610,33 +7602,32 @@ You can also visit a hosted version of the documentation on [constructs.dev](htt
 
 ## Versioning
 
-This project is explicitly not tracking the Terraform random Provider version 1:1. In fact, it always tracks \`latest\` of \`~>2.0\` with every release. If there are scenarios where you explicitly have to pin your provider version, you can do so by generating the [provider constructs manually](https://cdk.tf/imports).
+This project is explicitly not tracking the Terraform random provider version 1:1. In fact, it always tracks \`latest\` of \`~>2.0\` with every release. If there are scenarios where you explicitly have to pin your provider version, you can do so by [generating the provider constructs manually](https://cdk.tf/imports).
 
 These are the upstream dependencies:
 
-- [Terraform CDK](https://cdk.tf)
-- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0)
-    - This links to the minimum version being tracked, you can find the latest released version [in our releases](https://github.com/cdktf/cdktf-provider-random/releases)
+- [CDK for Terraform](https://cdk.tf)
+- [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/2.0.0)
 - [Terraform Engine](https://terraform.io)
 
 If there are breaking changes (backward incompatible) in any of the above, the major version of this project will be bumped.
 
 ## Features / Issues / Bugs
 
-Please report bugs and issues to the [terraform cdk](https://cdk.tf) project:
+Please report bugs and issues to the [CDK for Terraform](https://cdk.tf) project:
 
 - [Create bug report](https://cdk.tf/bug)
 - [Create feature request](https://cdk.tf/feature)
 
 ## Contributing
 
-### projen
+### Projen
 
-This is mostly based on [projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
+This is mostly based on [Projen](https://github.com/eladb/projen), which takes care of generating the entire repository.
 
-### cdktf-provider-project based on projen
+### cdktf-provider-project based on Projen
 
-There's a custom [project builder](https://github.com/hashicorp/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` providers.
+There's a custom [project builder](https://github.com/cdktf/cdktf-provider-project) which encapsulate the common settings for all \`cdktf\` prebuilt providers.
 
 ### Provider Version
 
@@ -7644,7 +7635,7 @@ The provider version can be adjusted in [./.projenrc.js](./.projenrc.js).
 
 ### Repository Management
 
-The repository is managed by [Repository Manager](https://github.com/hashicorp/cdktf-repository-manager/)
+The repository is managed by [CDKTF Repository Manager](https://github.com/cdktf/cdktf-repository-manager/).
 ",
   "cdktf.json": "{
   "language": "typescript",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -90,20 +90,14 @@ test("README contains provided Namespace", () => {
 
   expect(snapshotWithVersion["README.md"]).toEqual(
     expect.stringContaining(
-      "- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/3.1.0)"
-    ) &&
-      expect.stringContaining(
-        "- This links to the minimum version being tracked, you can find the latest released version [in our releases](https://github.com/cdktf/cdktf-provider-random/releases)"
-      )
+      "- [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/3.1.0)"
+    )
   );
 
   expect(snapshotWithoutVersion["README.md"]).toEqual(
     expect.stringContaining(
-      "- [Terraform random Provider](https://registry.terraform.io/providers/hashicorp/random/)"
-    ) &&
-      expect.stringContaining(
-        "- This links to the minimum version being tracked, you can find the latest released version [in our releases](https://github.com/cdktf/cdktf-provider-random/releases)"
-      )
+      "- [Terraform random provider](https://registry.terraform.io/providers/hashicorp/random/)"
+    )
   );
 });
 


### PR DESCRIPTION
Couple of minor but IMO powerful improvements to the provider READMEs:

- Puts the true underlying version number in the title instead of the tracked version (I have never ever found the tracked version to be helpful in practice)
- Includes a link to the Registry page earlier on in the document (I look for this often and hate having to scroll so far down to find it)
- Removes text about "This links to the minimum version being tracked" which is no longer relevant as a result of Mark's changes merged in #342

It's worth noting that in the snapshot tests, `underlyingTerraformVersion` is always unset, but in the actual provider repos in practice, it is always set. See here for an example: https://github.com/cdktf/cdktf-provider-aws/blob/main/README.md