### PR TITLE
feat: publish a top-level README in Go repositories

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
               // sed -e is black magic and for whatever reason the string replace doesn't work so let's try it again:
               "sed -i 's/### Go/## Go Package/' .repo/dist/go/README.md",
               // Just straight up delete these full lines and everything in between them:
-              "sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' dist/go/README.md",
+              "sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' .repo/dist/go/README.md",
               `sed -i 's|Find auto-generated docs for this provider here:|Find auto-generated docs for this provider [here](https://${repositoryUrl}/blob/main/docs/API.go.md).|' .repo/dist/go/README.md`,
             ].join("\n"),
             continueOnError: true, // can be removed later once confirmed this works

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1042,6 +1042,17 @@ jobs:
         run: cd .repo/dist/go && copywrite headers
       - name: Remove copywrite hcl file
         run: rm -f .repo/dist/go/.copywrite.hcl
+      - name: Move the README file up a directory
+        run: mv .repo/dist/go/*/README.md .repo/dist/go/README.md
+        continue-on-error: true
+      - name: Remove some text from the README that doesn't apply to Go
+        run: |-
+          sed -i 's/# CDKTF prebuilt bindings for/# CDKTF Go bindings for/' .repo/dist/go/README.md
+          sed -i -e '/## Available Packages/,/### Go/!b' -e '/### Go/!d;p; s/### Go/## Go Package/' -e 'd' .repo/dist/go/README.md
+          sed -i 's/### Go/## Go Package/' .repo/dist/go/README.md
+          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' dist/go/README.md
+          sed -i 's|Find auto-generated docs for this provider here:|Find auto-generated docs for this provider [here](https://github.com/cdktf/cdktf-provider-random/blob/main/docs/API.go.md).|' .repo/dist/go/README.md
+        continue-on-error: true
       - name: Collect go Artifact
         run: mv .repo/dist dist
       - name: Release
@@ -3768,6 +3779,17 @@ jobs:
         run: cd .repo/dist/go && copywrite headers
       - name: Remove copywrite hcl file
         run: rm -f .repo/dist/go/.copywrite.hcl
+      - name: Move the README file up a directory
+        run: mv .repo/dist/go/*/README.md .repo/dist/go/README.md
+        continue-on-error: true
+      - name: Remove some text from the README that doesn't apply to Go
+        run: |-
+          sed -i 's/# CDKTF prebuilt bindings for/# CDKTF Go bindings for/' .repo/dist/go/README.md
+          sed -i -e '/## Available Packages/,/### Go/!b' -e '/### Go/!d;p; s/### Go/## Go Package/' -e 'd' .repo/dist/go/README.md
+          sed -i 's/### Go/## Go Package/' .repo/dist/go/README.md
+          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' dist/go/README.md
+          sed -i 's|Find auto-generated docs for this provider here:|Find auto-generated docs for this provider [here](https://github.com/cdktf/cdktf-provider-random/blob/main/docs/API.go.md).|' .repo/dist/go/README.md
+        continue-on-error: true
       - name: Collect go Artifact
         run: mv .repo/dist dist
       - name: Release
@@ -6443,6 +6465,17 @@ jobs:
         run: cd .repo/dist/go && copywrite headers
       - name: Remove copywrite hcl file
         run: rm -f .repo/dist/go/.copywrite.hcl
+      - name: Move the README file up a directory
+        run: mv .repo/dist/go/*/README.md .repo/dist/go/README.md
+        continue-on-error: true
+      - name: Remove some text from the README that doesn't apply to Go
+        run: |-
+          sed -i 's/# CDKTF prebuilt bindings for/# CDKTF Go bindings for/' .repo/dist/go/README.md
+          sed -i -e '/## Available Packages/,/### Go/!b' -e '/### Go/!d;p; s/### Go/## Go Package/' -e 'd' .repo/dist/go/README.md
+          sed -i 's/### Go/## Go Package/' .repo/dist/go/README.md
+          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' dist/go/README.md
+          sed -i 's|Find auto-generated docs for this provider here:|Find auto-generated docs for this provider [here](https://github.com/cdktf/cdktf-provider-random/blob/main/docs/API.go.md).|' .repo/dist/go/README.md
+        continue-on-error: true
       - name: Collect go Artifact
         run: mv .repo/dist dist
       - name: Release

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1050,7 +1050,7 @@ jobs:
           sed -i 's/# CDKTF prebuilt bindings for/# CDKTF Go bindings for/' .repo/dist/go/README.md
           sed -i -e '/## Available Packages/,/### Go/!b' -e '/### Go/!d;p; s/### Go/## Go Package/' -e 'd' .repo/dist/go/README.md
           sed -i 's/### Go/## Go Package/' .repo/dist/go/README.md
-          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' dist/go/README.md
+          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' .repo/dist/go/README.md
           sed -i 's|Find auto-generated docs for this provider here:|Find auto-generated docs for this provider [here](https://github.com/cdktf/cdktf-provider-random/blob/main/docs/API.go.md).|' .repo/dist/go/README.md
         continue-on-error: true
       - name: Collect go Artifact
@@ -3787,7 +3787,7 @@ jobs:
           sed -i 's/# CDKTF prebuilt bindings for/# CDKTF Go bindings for/' .repo/dist/go/README.md
           sed -i -e '/## Available Packages/,/### Go/!b' -e '/### Go/!d;p; s/### Go/## Go Package/' -e 'd' .repo/dist/go/README.md
           sed -i 's/### Go/## Go Package/' .repo/dist/go/README.md
-          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' dist/go/README.md
+          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' .repo/dist/go/README.md
           sed -i 's|Find auto-generated docs for this provider here:|Find auto-generated docs for this provider [here](https://github.com/cdktf/cdktf-provider-random/blob/main/docs/API.go.md).|' .repo/dist/go/README.md
         continue-on-error: true
       - name: Collect go Artifact
@@ -6473,7 +6473,7 @@ jobs:
           sed -i 's/# CDKTF prebuilt bindings for/# CDKTF Go bindings for/' .repo/dist/go/README.md
           sed -i -e '/## Available Packages/,/### Go/!b' -e '/### Go/!d;p; s/### Go/## Go Package/' -e 'd' .repo/dist/go/README.md
           sed -i 's/### Go/## Go Package/' .repo/dist/go/README.md
-          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' dist/go/README.md
+          sed -i -e '/API.typescript.md/,/You can also visit a hosted version/!b' -e 'd' .repo/dist/go/README.md
           sed -i 's|Find auto-generated docs for this provider here:|Find auto-generated docs for this provider [here](https://github.com/cdktf/cdktf-provider-random/blob/main/docs/API.go.md).|' .repo/dist/go/README.md
         continue-on-error: true
       - name: Collect go Artifact


### PR DESCRIPTION
While working on #370, I realized that it'd be nice if the Go repos also have the same deprecation message. That got me thinking that the Go repos could use a better README in general. After doing some digging, I discovered that the full README [actually gets copied](https://github.com/cdktf/cdktf-provider-random-go/blob/main/random/README.md) into the Go repo, but it's buried a level lower so it's not visible if you're viewing [the main repo](https://github.com/cdktf/cdktf-provider-random-go/) which just has a barebones README that basically tells you nothing.

This moves the README up a level in the Go repo and then uses some `sed` black magic to remove/replace parts of the text that aren't relevant to the Go package. It isn't the prettiest code to write, but it was a fun challenge to figure out!