### PR TITLE
feat: Make author address overridable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,6 @@ export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
   readonly deprecationDate?: string;
 }
 
-const authorAddress = "https://hashicorp.com";
 const getMavenName = (providerName: string): string => {
   return ["null", "random"].includes(providerName)
     ? `${providerName}_provider`
@@ -105,6 +104,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       isDeprecated,
       deprecationDate,
       authorName = "HashiCorp",
+      authorAddress = "https://hashicorp.com",
       namespace = "cdktf",
       githubNamespace = "cdktf",
       mavenEndpoint = "https://hashicorp.oss.sonatype.org",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1889,7 +1889,7 @@ You can also visit a hosted version of the documentation on [constructs.dev](htt
   },
   "author": {
     "name": "HashiCorp",
-    "url": "https://hashicorp.com",
+    "url": "https://github.com/cdktf",
     "organization": true
   },
   "devDependencies": {
@@ -4353,7 +4353,7 @@ The repository is managed by [CDKTF Repository Manager](https://github.com/cdktf
   },
   "author": {
     "name": "HashiCorp",
-    "url": "https://hashicorp.com",
+    "url": "https://github.com/cdktf",
     "organization": true
   },
   "devDependencies": {
@@ -7099,7 +7099,7 @@ The repository is managed by [CDKTF Repository Manager](https://github.com/cdktf
   },
   "author": {
     "name": "HashiCorp",
-    "url": "https://hashicorp.com",
+    "url": "https://github.com/cdktf",
     "organization": true
   },
   "devDependencies": {
@@ -9794,7 +9794,7 @@ The repository is managed by [CDKTF Repository Manager](https://github.com/cdktf
   },
   "author": {
     "name": "HashiCorp",
-    "url": "https://hashicorp.com",
+    "url": "https://github.com/cdktf",
     "organization": true
   },
   "devDependencies": {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,7 +13,7 @@ const getProject = (
     name: "test",
     terraformProvider: "random@~>2.0",
     author: "cdktf-team",
-    authorAddress: "cdktf-team address",
+    authorAddress: "https://github.com/cdktf",
     cdktfVersion: "0.10.3",
     constructsVersion: "10.0.0",
     defaultReleaseBranch: "main",


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #382

### Description

The author's address was hard-coded. I made it settable from the config.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
