### PR TITLE
feat: Make maven group ID overridable

### DIFF
--- a/API.md
+++ b/API.md
@@ -1675,6 +1675,7 @@ const cdktfProviderProjectOptions: CdktfProviderProjectOptions = { ... }
 | <code><a href="#@cdktf/provider-project.CdktfProviderProjectOptions.property.githubNamespace">githubNamespace</a></code> | <code>string</code> | defaults to "cdktf" previously was "hashicorp". |
 | <code><a href="#@cdktf/provider-project.CdktfProviderProjectOptions.property.isDeprecated">isDeprecated</a></code> | <code>boolean</code> | Whether or not this prebuilt provider is deprecated. |
 | <code><a href="#@cdktf/provider-project.CdktfProviderProjectOptions.property.mavenEndpoint">mavenEndpoint</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@cdktf/provider-project.CdktfProviderProjectOptions.property.mavenGroupId">mavenGroupId</a></code> | <code>string</code> | defaults to "com.${mavenOrg}". |
 | <code><a href="#@cdktf/provider-project.CdktfProviderProjectOptions.property.mavenOrg">mavenOrg</a></code> | <code>string</code> | defaults to "hashicorp". |
 | <code><a href="#@cdktf/provider-project.CdktfProviderProjectOptions.property.namespace">namespace</a></code> | <code>string</code> | defaults to "cdktf". |
 | <code><a href="#@cdktf/provider-project.CdktfProviderProjectOptions.property.nugetOrg">nugetOrg</a></code> | <code>string</code> | defaults to "HashiCorp". |
@@ -3997,6 +3998,18 @@ public readonly mavenEndpoint: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `mavenGroupId`<sup>Optional</sup> <a name="mavenGroupId" id="@cdktf/provider-project.CdktfProviderProjectOptions.property.mavenGroupId"></a>
+
+```typescript
+public readonly mavenGroupId: string;
+```
+
+- *Type:* string
+
+defaults to "com.${mavenOrg}".
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
    */
   readonly mavenOrg?: string;
   /**
+   * defaults to "com.${mavenOrg}"
+   */
+  readonly mavenGroupId?: string;
+  /**
    * The year of the creation of the repository, for copyright purposes.
    * Will fall back to the current year if not specified.
    */
@@ -123,7 +127,8 @@ export class CdktfProviderProject extends cdk.JsiiProject {
     const nugetName = `${nugetOrg}.${pascalCase(
       namespace
     )}.Providers.${pascalCase(providerName)}`;
-    const mavenName = `com.${mavenOrg}.${namespace}.providers.${getMavenName(
+    const mavenGroupId = options.mavenGroupId ?? `com.${mavenOrg}`;
+    const mavenName = `${mavenGroupId}.${namespace}.providers.${getMavenName(
       providerName
     )}`;
     const repositoryUrl = `github.com/${githubNamespace}/${namespace}-provider-${providerName.replace(
@@ -151,7 +156,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       },
       publishToMaven: {
         javaPackage: mavenName,
-        mavenGroupId: `com.${mavenOrg}`,
+        mavenGroupId: mavenGroupId,
         mavenArtifactId: `${namespace}-provider-${providerName}`,
         mavenEndpoint,
       },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -151,3 +151,29 @@ test("has a custom workflow and README if the project is deprecated", () => {
     )
   );
 });
+
+test("override maven org", () => {
+  const snapshot = synthSnapshot(getProject({ mavenOrg: "gofer" }));
+
+  expect(JSON.parse(snapshot["package.json"])).toHaveProperty(
+    "jsii.targets.java.maven.groupId",
+    "com.gofer"
+  );
+  expect(JSON.parse(snapshot["package.json"])).toHaveProperty(
+    "jsii.targets.java.package",
+    "com.gofer.cdktf.providers.random_provider"
+  );
+});
+
+test("override maven group id", () => {
+  const snapshot = synthSnapshot(getProject({ mavenGroupId: "dev.gofer" }));
+
+  expect(JSON.parse(snapshot["package.json"])).toHaveProperty(
+    "jsii.targets.java.maven.groupId",
+    "dev.gofer"
+  );
+  expect(JSON.parse(snapshot["package.json"])).toHaveProperty(
+    "jsii.targets.java.package",
+    "dev.gofer.cdktf.providers.random_provider"
+  );
+});


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #385

### Description

The maven group ID starts with `com.` by default. I added an option to override the whole group ID.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
