### PR TITLE
fix: Prevent accidental package deprecations

### DIFF
--- a/src/deprecate-packages.ts
+++ b/src/deprecate-packages.ts
@@ -62,14 +62,14 @@ export class DeprecatePackages {
             name: "Check deprecation status",
             id: "check_status",
             run: [
-              `IS_DEPRECATED=$(npm pkg get cdktf.isDeprecated | tr -d '"')`,
+              `IS_DEPRECATED=$(cat package.json | jq .cdktf.isDeprecated -r)`,
               `echo "is_deprecated=$IS_DEPRECATED"`, // for easier debugging
               `echo "is_deprecated=$IS_DEPRECATED" >> $GITHUB_OUTPUT`,
             ].join("\n"),
           },
           {
             name: "Deprecate the package on NPM",
-            if: "steps.check_status.outputs.is_deprecated",
+            if: "steps.check_status.outputs.is_deprecated == 'true' || steps.check_status.outputs.is_deprecated == true",
             run: [
               'npm set "//$NPM_REGISTRY/:_authToken=$NPM_TOKEN"',
               `npm deprecate ${packageInfo.npm.name} "${deprecationMessageForNPM}"`,

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -518,11 +518,11 @@ jobs:
       - name: Check deprecation status
         id: check_status
         run: |-
-          IS_DEPRECATED=$(npm pkg get cdktf.isDeprecated | tr -d '"')
+          IS_DEPRECATED=$(cat package.json | jq .cdktf.isDeprecated -r)
           echo "is_deprecated=$IS_DEPRECATED"
           echo "is_deprecated=$IS_DEPRECATED" >> $GITHUB_OUTPUT
       - name: Deprecate the package on NPM
-        if: steps.check_status.outputs.is_deprecated
+        if: steps.check_status.outputs.is_deprecated == 'true' || steps.check_status.outputs.is_deprecated == true
         env:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
@@ -2802,11 +2802,11 @@ jobs:
       - name: Check deprecation status
         id: check_status
         run: |-
-          IS_DEPRECATED=$(npm pkg get cdktf.isDeprecated | tr -d '"')
+          IS_DEPRECATED=$(cat package.json | jq .cdktf.isDeprecated -r)
           echo "is_deprecated=$IS_DEPRECATED"
           echo "is_deprecated=$IS_DEPRECATED" >> $GITHUB_OUTPUT
       - name: Deprecate the package on NPM
-        if: steps.check_status.outputs.is_deprecated
+        if: steps.check_status.outputs.is_deprecated == 'true' || steps.check_status.outputs.is_deprecated == true
         env:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
@@ -5530,11 +5530,11 @@ jobs:
       - name: Check deprecation status
         id: check_status
         run: |-
-          IS_DEPRECATED=$(npm pkg get cdktf.isDeprecated | tr -d '"')
+          IS_DEPRECATED=$(cat package.json | jq .cdktf.isDeprecated -r)
           echo "is_deprecated=$IS_DEPRECATED"
           echo "is_deprecated=$IS_DEPRECATED" >> $GITHUB_OUTPUT
       - name: Deprecate the package on NPM
-        if: steps.check_status.outputs.is_deprecated
+        if: steps.check_status.outputs.is_deprecated == 'true' || steps.check_status.outputs.is_deprecated == true
         env:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
@@ -8243,11 +8243,11 @@ jobs:
       - name: Check deprecation status
         id: check_status
         run: |-
-          IS_DEPRECATED=$(npm pkg get cdktf.isDeprecated | tr -d '"')
+          IS_DEPRECATED=$(cat package.json | jq .cdktf.isDeprecated -r)
           echo "is_deprecated=$IS_DEPRECATED"
           echo "is_deprecated=$IS_DEPRECATED" >> $GITHUB_OUTPUT
       - name: Deprecate the package on NPM
-        if: steps.check_status.outputs.is_deprecated
+        if: steps.check_status.outputs.is_deprecated == 'true' || steps.check_status.outputs.is_deprecated == true
         env:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Description

The release workflow allowed `is_deprecated = false` packages to still get deprecated because of some weirdness within the github actions. This should make the filter a bit more secure.
