### PR TITLE
fix(cli): Fix version range matching for 0.x version ranges with the ~> operator

### DIFF
--- a/src/scripts/check-for-upgrades.ts
+++ b/src/scripts/check-for-upgrades.ts
@@ -119,7 +119,7 @@ async function getCurrentProviderVersion() {
 }
 
 // SEE NOTICE AT THE TOP WHY THIS IS INLINED CURRENTLY
-// copied from https://github.com/hashicorp/terraform-cdk/blob/b23fc173715e90c0a5b8c8633d9ec7f71edf9ed4/packages/cdktf-cli/lib/dependencies/version-constraints.ts
+// copied from https://github.com/hashicorp/terraform-cdk/blob/df858ccf4ac71a168e3636f053c6743324c98332/packages/%40cdktf/cli-core/src/lib/dependencies/version-constraints.ts
 // and converted to JavaScript
 
 // constraints can be prefixed with "~>", ">", "<", "=", ">=", "<=" or "!="
@@ -158,15 +158,25 @@ function versionMatchesConstraint(version, constraint) {
       case "~>": {
         // allows rightmost version component to increment
 
+        const parts = parsed.version.split(".");
+        const minorSpecified = parts.length === 2;
+        const majorIsZero = parts[0] === "0";
+
         // ~>2.0 which allows 2.1 and 2.1.1 needs special handling as
         // npm semver handles "~" differently for ~2.0 than for ~2 or ~2.1.0
         // So we need to use "^" (e.g. ^2.0) for this case
         // see: https://github.com/npm/node-semver/issues/11
-        const allowMinorAndPatchOnly = parsed.version.split(".").length === 2;
+        const allowMinorAndPatchOnly = minorSpecified;
 
-        const range = allowMinorAndPatchOnly
+        let range = allowMinorAndPatchOnly
           ? \`^\${parsed.version}\`
           : \`~\${parsed.version}\`;
+
+        // versions below 1.0 are treated a bit differently in NPM than in Terraform
+        // meaning that NPMs ^0.4 doesn't allow 0.55 while TFs ~>0.4 allows 0.55
+        if (majorIsZero && minorSpecified) {
+          range = \`>=\${parsed.version} <1.0.0\`;
+        }
 
         return semver.satisfies(version, range);
       }

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -4557,7 +4557,7 @@ async function getCurrentProviderVersion() {
 }
 
 // SEE NOTICE AT THE TOP WHY THIS IS INLINED CURRENTLY
-// copied from https://github.com/hashicorp/terraform-cdk/blob/b23fc173715e90c0a5b8c8633d9ec7f71edf9ed4/packages/cdktf-cli/lib/dependencies/version-constraints.ts
+// copied from https://github.com/hashicorp/terraform-cdk/blob/df858ccf4ac71a168e3636f053c6743324c98332/packages/%40cdktf/cli-core/src/lib/dependencies/version-constraints.ts
 // and converted to JavaScript
 
 // constraints can be prefixed with "~>", ">", "<", "=", ">=", "<=" or "!="
@@ -4596,15 +4596,25 @@ function versionMatchesConstraint(version, constraint) {
       case "~>": {
         // allows rightmost version component to increment
 
+        const parts = parsed.version.split(".");
+        const minorSpecified = parts.length === 2;
+        const majorIsZero = parts[0] === "0";
+
         // ~>2.0 which allows 2.1 and 2.1.1 needs special handling as
         // npm semver handles "~" differently for ~2.0 than for ~2 or ~2.1.0
         // So we need to use "^" (e.g. ^2.0) for this case
         // see: https://github.com/npm/node-semver/issues/11
-        const allowMinorAndPatchOnly = parsed.version.split(".").length === 2;
+        const allowMinorAndPatchOnly = minorSpecified;
 
-        const range = allowMinorAndPatchOnly
+        let range = allowMinorAndPatchOnly
           ? \`^\${parsed.version}\`
           : \`~\${parsed.version}\`;
+
+        // versions below 1.0 are treated a bit differently in NPM than in Terraform
+        // meaning that NPMs ^0.4 doesn't allow 0.55 while TFs ~>0.4 allows 0.55
+        if (majorIsZero && minorSpecified) {
+          range = \`>=\${parsed.version} <1.0.0\`;
+        }
 
         return semver.satisfies(version, range);
       }
@@ -7303,7 +7313,7 @@ async function getCurrentProviderVersion() {
 }
 
 // SEE NOTICE AT THE TOP WHY THIS IS INLINED CURRENTLY
-// copied from https://github.com/hashicorp/terraform-cdk/blob/b23fc173715e90c0a5b8c8633d9ec7f71edf9ed4/packages/cdktf-cli/lib/dependencies/version-constraints.ts
+// copied from https://github.com/hashicorp/terraform-cdk/blob/df858ccf4ac71a168e3636f053c6743324c98332/packages/%40cdktf/cli-core/src/lib/dependencies/version-constraints.ts
 // and converted to JavaScript
 
 // constraints can be prefixed with "~>", ">", "<", "=", ">=", "<=" or "!="
@@ -7342,15 +7352,25 @@ function versionMatchesConstraint(version, constraint) {
       case "~>": {
         // allows rightmost version component to increment
 
+        const parts = parsed.version.split(".");
+        const minorSpecified = parts.length === 2;
+        const majorIsZero = parts[0] === "0";
+
         // ~>2.0 which allows 2.1 and 2.1.1 needs special handling as
         // npm semver handles "~" differently for ~2.0 than for ~2 or ~2.1.0
         // So we need to use "^" (e.g. ^2.0) for this case
         // see: https://github.com/npm/node-semver/issues/11
-        const allowMinorAndPatchOnly = parsed.version.split(".").length === 2;
+        const allowMinorAndPatchOnly = minorSpecified;
 
-        const range = allowMinorAndPatchOnly
+        let range = allowMinorAndPatchOnly
           ? \`^\${parsed.version}\`
           : \`~\${parsed.version}\`;
+
+        // versions below 1.0 are treated a bit differently in NPM than in Terraform
+        // meaning that NPMs ^0.4 doesn't allow 0.55 while TFs ~>0.4 allows 0.55
+        if (majorIsZero && minorSpecified) {
+          range = \`>=\${parsed.version} <1.0.0\`;
+        }
 
         return semver.satisfies(version, range);
       }
@@ -9998,7 +10018,7 @@ async function getCurrentProviderVersion() {
 }
 
 // SEE NOTICE AT THE TOP WHY THIS IS INLINED CURRENTLY
-// copied from https://github.com/hashicorp/terraform-cdk/blob/b23fc173715e90c0a5b8c8633d9ec7f71edf9ed4/packages/cdktf-cli/lib/dependencies/version-constraints.ts
+// copied from https://github.com/hashicorp/terraform-cdk/blob/df858ccf4ac71a168e3636f053c6743324c98332/packages/%40cdktf/cli-core/src/lib/dependencies/version-constraints.ts
 // and converted to JavaScript
 
 // constraints can be prefixed with "~>", ">", "<", "=", ">=", "<=" or "!="
@@ -10037,15 +10057,25 @@ function versionMatchesConstraint(version, constraint) {
       case "~>": {
         // allows rightmost version component to increment
 
+        const parts = parsed.version.split(".");
+        const minorSpecified = parts.length === 2;
+        const majorIsZero = parts[0] === "0";
+
         // ~>2.0 which allows 2.1 and 2.1.1 needs special handling as
         // npm semver handles "~" differently for ~2.0 than for ~2 or ~2.1.0
         // So we need to use "^" (e.g. ^2.0) for this case
         // see: https://github.com/npm/node-semver/issues/11
-        const allowMinorAndPatchOnly = parsed.version.split(".").length === 2;
+        const allowMinorAndPatchOnly = minorSpecified;
 
-        const range = allowMinorAndPatchOnly
+        let range = allowMinorAndPatchOnly
           ? \`^\${parsed.version}\`
           : \`~\${parsed.version}\`;
+
+        // versions below 1.0 are treated a bit differently in NPM than in Terraform
+        // meaning that NPMs ^0.4 doesn't allow 0.55 while TFs ~>0.4 allows 0.55
+        if (majorIsZero && minorSpecified) {
+          range = \`>=\${parsed.version} <1.0.0\`;
+        }
 
         return semver.satisfies(version, range);
       }


### PR DESCRIPTION
based on https://github.com/hashicorp/terraform-cdk/pull/3403
