### PR TITLE
chore: Fix `go get` usage for Golang within readme

### DIFF
--- a/src/readme.ts
+++ b/src/readme.ts
@@ -131,7 +131,12 @@ The go package is generated into the [\`${
 
 \`go get ${packageInfo.publishToGo?.moduleName}/${
       packageInfo.publishToGo?.packageName
-    }\`
+    }/<version>\`
+
+Where \`<version>\` is the version of the prebuilt provider you would like to use e.g. \`v11\`. The full module name can be found
+within the [go.mod](https://${packageInfo.publishToGo?.moduleName}/blob/main/${
+      packageInfo.publishToGo?.packageName
+    }/go.mod#L1) file.
 
 ## Docs
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1826,7 +1826,10 @@ The Maven package is available at [https://mvnrepository.com/artifact/com.hashic
 
 The go package is generated into the [\`github.com/cdktf/cdktf-provider-random-go\`](https://github.com/cdktf/cdktf-provider-random-go) package.
 
-\`go get github.com/cdktf/cdktf-provider-random-go/random\`
+\`go get github.com/cdktf/cdktf-provider-random-go/random/<version>\`
+
+Where \`<version>\` is the version of the prebuilt provider you would like to use e.g. \`v11\`. The full module name can be found
+within the [go.mod](https://github.com/cdktf/cdktf-provider-random-go/blob/main/random/go.mod#L1) file.
 
 ## Docs
 
@@ -4250,7 +4253,10 @@ The Maven package is available at [https://mvnrepository.com/artifact/com.hashic
 
 The go package is generated into the [\`github.com/cdktf/cdktf-provider-random-go\`](https://github.com/cdktf/cdktf-provider-random-go) package.
 
-\`go get github.com/cdktf/cdktf-provider-random-go/random\`
+\`go get github.com/cdktf/cdktf-provider-random-go/random/<version>\`
+
+Where \`<version>\` is the version of the prebuilt provider you would like to use e.g. \`v11\`. The full module name can be found
+within the [go.mod](https://github.com/cdktf/cdktf-provider-random-go/blob/main/random/go.mod#L1) file.
 
 ## Docs
 
@@ -7006,7 +7012,10 @@ The Maven package is available at [https://mvnrepository.com/artifact/com.hashic
 
 The go package is generated into the [\`github.com/cdktf/cdktf-provider-random-go\`](https://github.com/cdktf/cdktf-provider-random-go) package.
 
-\`go get github.com/cdktf/cdktf-provider-random-go/random\`
+\`go get github.com/cdktf/cdktf-provider-random-go/random/<version>\`
+
+Where \`<version>\` is the version of the prebuilt provider you would like to use e.g. \`v11\`. The full module name can be found
+within the [go.mod](https://github.com/cdktf/cdktf-provider-random-go/blob/main/random/go.mod#L1) file.
 
 ## Docs
 
@@ -9711,7 +9720,10 @@ The Maven package is available at [https://mvnrepository.com/artifact/com.hashic
 
 The go package is generated into the [\`github.com/cdktf/cdktf-provider-random-go\`](https://github.com/cdktf/cdktf-provider-random-go) package.
 
-\`go get github.com/cdktf/cdktf-provider-random-go/random\`
+\`go get github.com/cdktf/cdktf-provider-random-go/random/<version>\`
+
+Where \`<version>\` is the version of the prebuilt provider you would like to use e.g. \`v11\`. The full module name can be found
+within the [go.mod](https://github.com/cdktf/cdktf-provider-random-go/blob/main/random/go.mod#L1) file.
 
 ## Docs
 


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Description

Our readme shows an incorrect command to execute for Golang in order to use the prebuilt providers within CDKTF projects.

This PR updates that language to be clearer to the users.


### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
