### PR TITLE
fix: Randomize locking job schedule to prevent running into github rate limits

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,7 +3,7 @@
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 2 4 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest

--- a/src/lock-issues.ts
+++ b/src/lock-issues.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { createHash } from "crypto";
 import { javascript } from "projen";
 import { JobPermission } from "projen/lib/github/workflows-model";
 
@@ -17,8 +18,14 @@ export class LockIssues {
 
     if (!workflow) throw new Error("no workflow defined");
 
+    const projectNameHash = createHash("md5")
+      .update(project.name)
+      .digest("hex");
+    const scheduleHour = parseInt(projectNameHash.slice(0, 2), 16) % 24;
+    const scheduleMinute = parseInt(projectNameHash.slice(2, 4), 16) % 24;
+
     workflow.on({
-      schedule: [{ cron: "20 2 * * *" }],
+      schedule: [{ cron: `${scheduleHour} ${scheduleMinute} * * *` }],
     });
 
     workflow.addJob("lock", {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -412,7 +412,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 17 16 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -2642,7 +2642,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 17 16 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -5386,7 +5386,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 17 16 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -8127,7 +8127,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 17 16 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -10850,7 +10850,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 20 2 * * *
+    - cron: 7 12 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/cdktf/.github/blob/main/CONTRIBUTING.md

-->

### Description

As seen in the following images, we seem to be running into a secondary rate limit when we try to lock issues within our provider repositories. 

<img width="1671" alt="image" src="https://github.com/cdktf/cdktf-provider-project/assets/573531/6fde8b66-653e-4cab-8231-222dae3f73d0">

<img width="645" alt="image" src="https://github.com/cdktf/cdktf-provider-project/assets/573531/588858f8-0546-4c3b-b9f4-611626c7ef2d">

<img width="740" alt="image" src="https://github.com/cdktf/cdktf-provider-project/assets/573531/0caa4347-2fbe-427e-b57e-88a7bd121d7c">

This PR tries to use a hash of the project name to generate a somewhat unique cron schedule across all our repositories. I have to say that I haven't really thought too hard about this, so if you feel there are problems in my approach, please let me know.