### PR TITLE
chore: improve random cron generation

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,7 +3,7 @@
 name: lock
 on:
   schedule:
-    - cron: 2 4 * * *
+    - cron: 52 2 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest

--- a/src/alert-open-prs.ts
+++ b/src/alert-open-prs.ts
@@ -6,6 +6,7 @@
 import { cdk } from "projen";
 import { GithubWorkflow } from "projen/lib/github";
 import { JobPermission } from "projen/lib/github/workflows-model";
+import { generateRandomCron, Schedule } from "./util/random-cron";
 
 const DEFAULT_MAX_HOURS_OPEN = 2;
 
@@ -25,8 +26,17 @@ export class AlertOpenPrs {
 
     const workflow = new GithubWorkflow(project.github!, "alert-open-prs");
     workflow.on({
-      workflowDispatch: {},
-      schedule: [{ cron: "* */12 * * 1-5" }], // every 12 hours, Monday-Friday
+      // run on weekdays sometime during working hours (8am-4pm UTC)
+      schedule: [
+        {
+          cron: generateRandomCron({
+            project,
+            maxHour: 8,
+            hourOffset: 8,
+            schedule: Schedule.Weekdays,
+          }),
+        },
+      ],
     });
     workflow.addJob("check-open-prs", {
       runsOn: ["ubuntu-latest"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { PackageInfo } from "./package-info";
 import { ProviderUpgrade } from "./provider-upgrade";
 import { CheckForUpgradesScriptFile } from "./scripts/check-for-upgrades";
 import { ShouldReleaseScriptFile } from "./scripts/should-release";
+import { generateRandomCron } from "./util/random-cron";
 
 // ensure new projects start with 1.0.0 so that every following breaking change leads to an increased major version
 const MIN_MAJOR_VERSION = 1;
@@ -449,6 +450,13 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       gitRemoteJob.name +=
         " or cancel via faking a SHA if release was cancelled";
     }
+
+    const staleWorkflow = this.tryFindObjectFile(".github/workflows/stale.yml");
+    staleWorkflow?.addOverride("on.schedule", [
+      {
+        cron: generateRandomCron({ project: this, maxHour: 4, hourOffset: 1 }),
+      },
+    ]);
 
     // Submodule documentation generation
     this.gitignore.exclude("API.md"); // ignore the old file, we now generate it in the docs folder

--- a/src/lock-issues.ts
+++ b/src/lock-issues.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { createHash } from "crypto";
 import { javascript } from "projen";
 import { JobPermission } from "projen/lib/github/workflows-model";
+import { generateRandomCron } from "./util/random-cron";
 
 /**
  * Automatically locks issues and PRs after 7 days. Note that 90% of the issues and PRs
@@ -18,14 +18,9 @@ export class LockIssues {
 
     if (!workflow) throw new Error("no workflow defined");
 
-    const projectNameHash = createHash("md5")
-      .update(project.name)
-      .digest("hex");
-    const scheduleHour = parseInt(projectNameHash.slice(0, 2), 16) % 24;
-    const scheduleMinute = parseInt(projectNameHash.slice(2, 4), 16) % 24;
-
     workflow.on({
-      schedule: [{ cron: `${scheduleHour} ${scheduleMinute} * * *` }],
+      // run daily sometime between midnight and 6am UTC
+      schedule: [{ cron: generateRandomCron({ project, maxHour: 6 }) }],
     });
 
     workflow.addJob("lock", {

--- a/src/util/random-cron.ts
+++ b/src/util/random-cron.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { createHash } from "crypto";
+import { javascript } from "projen";
+
+export enum Schedule {
+  Daily = "DAILY",
+  Weekly = "WEEKLY",
+  Monthly = "MONTHLY",
+  Weekdays = "WEEKDAYS",
+}
+
+export interface RandomCronOptions {
+  project: javascript.NodeProject;
+  maxHour?: number;
+  hourOffset?: number;
+  schedule?: Schedule;
+}
+
+export function generateRandomCron(options: RandomCronOptions) {
+  const maxHour = options.maxHour ? Math.round(options.maxHour) : 24;
+  const hourOffset = options.hourOffset ? Math.round(options.hourOffset) : 0;
+  const schedule = options.schedule || Schedule.Daily; // default to daily
+
+  const project = options.project;
+  const hash = createHash("md5").update(project.name).digest("hex");
+  const hour = maxHour === 0 ? 0 : parseInt(hash.slice(0, 2), 16) % maxHour;
+  const minute = parseInt(hash.slice(2, 4), 16) % 60;
+
+  const dayOfMonth = schedule === Schedule.Monthly ? "1" : "*";
+  const dayOfWeek =
+    schedule === Schedule.Weekly
+      ? "1"
+      : schedule === Schedule.Weekdays
+      ? "1-5"
+      : "*";
+
+  return `${minute} ${(hour + hourOffset) % 24} ${dayOfMonth} * ${dayOfWeek}`;
+}

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -412,7 +412,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 17 16 * * *
+    - cron: 4 5 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -857,7 +857,7 @@ jobs:
 name: stale
 on:
   schedule:
-    - cron: 0 1 * * *
+    - cron: 4 2 * * *
   workflow_dispatch: {}
 jobs:
   stale:
@@ -2159,9 +2159,8 @@ updates:
 
 name: alert-open-prs
 on:
-  workflow_dispatch: {}
   schedule:
-    - cron: "* */12 * * 1-5"
+    - cron: 4 9 * * 1-5
 jobs:
   check-open-prs:
     runs-on: ubuntu-latest
@@ -2642,7 +2641,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 17 16 * * *
+    - cron: 4 5 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -3151,7 +3150,7 @@ jobs:
 name: stale
 on:
   schedule:
-    - cron: 0 1 * * *
+    - cron: 4 2 * * *
   workflow_dispatch: {}
 jobs:
   stale:
@@ -4876,9 +4875,8 @@ updates:
 
 name: alert-open-prs
 on:
-  workflow_dispatch: {}
   schedule:
-    - cron: "* */12 * * 1-5"
+    - cron: 4 9 * * 1-5
 jobs:
   check-open-prs:
     runs-on: ubuntu-latest
@@ -5386,7 +5384,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 17 16 * * *
+    - cron: 4 5 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -5919,7 +5917,7 @@ jobs:
 name: stale
 on:
   schedule:
-    - cron: 0 1 * * *
+    - cron: 4 2 * * *
   workflow_dispatch: {}
 jobs:
   stale:
@@ -7644,9 +7642,8 @@ updates:
 
 name: alert-open-prs
 on:
-  workflow_dispatch: {}
   schedule:
-    - cron: "* */12 * * 1-5"
+    - cron: 4 9 * * 1-5
 jobs:
   check-open-prs:
     runs-on: ubuntu-latest
@@ -8127,7 +8124,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 17 16 * * *
+    - cron: 4 5 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -8636,7 +8633,7 @@ jobs:
 name: stale
 on:
   schedule:
-    - cron: 0 1 * * *
+    - cron: 4 2 * * *
   workflow_dispatch: {}
 jobs:
   stale:
@@ -10361,9 +10358,8 @@ updates:
 
 name: alert-open-prs
 on:
-  workflow_dispatch: {}
   schedule:
-    - cron: "* */12 * * 1-5"
+    - cron: 12 15 * * 1-5
 jobs:
   check-open-prs:
     runs-on: ubuntu-latest
@@ -10850,7 +10846,7 @@ jobs:
 name: lock
 on:
   schedule:
-    - cron: 7 12 * * *
+    - cron: 12 1 * * *
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -11363,7 +11359,7 @@ jobs:
 name: stale
 on:
   schedule:
-    - cron: 0 1 * * *
+    - cron: 12 4 * * *
   workflow_dispatch: {}
 jobs:
   stale:


### PR DESCRIPTION
I noticed the lock workflow was still failing sometimes, and from what I could tell the runs that failed were most likely to be during business hours (US time). I'm hoping we can address the issue by running during the night (early morning hours UTC).

While I was at it, I refactored Mutahhir's great work into a separate script so that it could be reused across workflows; another one that makes a fair number of API calls that could benefit from this approach is the stale workflow.