### PR TITLE
chore: fix autoclose community PR workflow

### DIFF
--- a/src/auto-close-community-issues.ts
+++ b/src/auto-close-community-issues.ts
@@ -32,7 +32,7 @@ export class AutoCloseCommunityIssues {
       },
     });
     prWorkflow.on({
-      pullRequest: {
+      pullRequestTarget: {
         types: ["opened"],
       },
     });
@@ -52,6 +52,7 @@ export class AutoCloseCommunityIssues {
     issueWorkflow.addJob("autoclose", {
       runsOn: ["ubuntu-latest"],
       permissions: {
+        contents: JobPermission.READ,
         issues: JobPermission.WRITE,
       },
       if: `github.event.issue.user.login != 'team-tf-cdk' && !contains(${maintainerStatuses}, github.event.issue.author_association)`,
@@ -83,6 +84,7 @@ export class AutoCloseCommunityIssues {
     prWorkflow.addJob("autoclose", {
       runsOn: ["ubuntu-latest"],
       permissions: {
+        contents: JobPermission.READ,
         pullRequests: JobPermission.WRITE,
       },
       if: `github.event.pull_request.user.login != 'team-tf-cdk' && !contains(${maintainerStatuses}, github.event.pull_request.author_association)`,

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -112,6 +112,7 @@ jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     if: github.event.issue.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.issue.author_association)
     steps:
@@ -130,13 +131,14 @@ jobs:
 
 name: auto-close-community-prs
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     if: github.event.pull_request.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
     steps:
@@ -2233,6 +2235,7 @@ jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     if: github.event.issue.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.issue.author_association)
     steps:
@@ -2251,13 +2254,14 @@ jobs:
 
 name: auto-close-community-prs
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     if: github.event.pull_request.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
     steps:
@@ -4949,6 +4953,7 @@ jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     if: github.event.issue.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.issue.author_association)
     steps:
@@ -4967,13 +4972,14 @@ jobs:
 
 name: auto-close-community-prs
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     if: github.event.pull_request.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
     steps:
@@ -7716,6 +7722,7 @@ jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     if: github.event.issue.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.issue.author_association)
     steps:
@@ -7734,13 +7741,14 @@ jobs:
 
 name: auto-close-community-prs
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     if: github.event.pull_request.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
     steps:
@@ -10432,6 +10440,7 @@ jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     if: github.event.issue.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.issue.author_association)
     steps:
@@ -10450,13 +10459,14 @@ jobs:
 
 name: auto-close-community-prs
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 jobs:
   autoclose:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     if: github.event.pull_request.user.login != 'team-tf-cdk' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
     steps:


### PR DESCRIPTION
I was trying to figure out why [this workflow failed](https://github.com/cdktf/cdktf-provider-kubernetes/actions/runs/8914139998/job/24506123846) which brought me to [this discussion thread](https://github.com/cli/cli/issues/8374) -- the solution is to make sure we're using `pull_request_target` on this workflow.