### PR TITLE
chore(ci): fix logic error in upgrade-node workflow

### DIFF
--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -40,19 +40,19 @@ jobs:
             const script = require('./projenrc/scripts/check-node-versions.js')
             await script({github, context, core})
       - name: Set the new minNodeVersion in .projenrc.ts
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         run: 'sed -i "s/minNodeVersion: \".*\",/minNodeVersion: \"$NEW_NODEJS_VERSION\",/" ./.projenrc.ts'
       - name: Activate Projen to propagate the new version everywhere
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         run: yarn projen
       - name: Get values for pull request
         id: latest_version
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         run: |-
           echo "value=$NEW_NODEJS_VERSION" >> $GITHUB_OUTPUT
           echo "short=$NEW_NODEJS_VERSION_SHORT" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        if: env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT
+        if: env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           commit-message: "chore!: increase minimum supported Node.js version to ${{ steps.latest_version.outputs.short }}"

--- a/projenrc/upgrade-node.ts
+++ b/projenrc/upgrade-node.ts
@@ -72,18 +72,18 @@ export class UpgradeNode {
           },
           {
             name: "Set the new minNodeVersion in .projenrc.ts",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             run: `sed -i "s/minNodeVersion: \\".*\\",/minNodeVersion: \\"$NEW_NODEJS_VERSION\\",/" ./.projenrc.ts`,
           },
           {
             name: "Activate Projen to propagate the new version everywhere",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             run: "yarn projen",
           },
           {
             name: "Get values for pull request",
             id: "latest_version",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             run: [
               `echo "value=$NEW_NODEJS_VERSION" >> $GITHUB_OUTPUT`,
               `echo "short=$NEW_NODEJS_VERSION_SHORT" >> $GITHUB_OUTPUT`,
@@ -91,7 +91,7 @@ export class UpgradeNode {
           },
           {
             name: "Create Pull Request",
-            if: "env.CURRENT_NODEJS_VERSION_SHORT != env.NEW_NODEJS_VERSION_SHORT",
+            if: "env.CURRENT_NODEJS_VERSION_SHORT < env.NEW_NODEJS_VERSION_SHORT",
             uses: "peter-evans/create-pull-request@v3",
             with: {
               "commit-message":


### PR DESCRIPTION
It shouldn't try to "upgrade" to Node 18 if it's already on Node 20.