### PR TITLE
fix(release): publish a GitHub release even if a particular package manager fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,6 +343,12 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       setSafeDirectory
     );
 
+    // always publish a new GitHub release, even when publishing to a particular package manager fails
+    const releaseWorkflow = this.tryFindObjectFile(
+      ".github/workflows/release.yml"
+    );
+    releaseWorkflow?.addOverride("jobs.release_github.needs", "release");
+
     // ensure we don't fail if the release file is not present
     const checkExistingTagStep = (
       this.release as any

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -549,13 +549,7 @@ jobs:
           npm deprecate @cdktf/provider-random "See https://cdk.tf/imports for details on how to continue to use the random provider in your CDK for Terraform (CDKTF) projects by generating the bindings locally."
   release_github:
     name: Publish to GitHub Releases
-    needs:
-      - release
-      - release_npm
-      - release_maven
-      - release_pypi
-      - release_nuget
-      - release_golang
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -2876,13 +2870,7 @@ jobs:
           npm deprecate @cdktf/provider-random "See https://cdk.tf/imports for details on how to continue to use the random provider in your CDK for Terraform (CDKTF) projects by generating the bindings locally."
   release_github:
     name: Publish to GitHub Releases
-    needs:
-      - release
-      - release_npm
-      - release_maven
-      - release_pypi
-      - release_nuget
-      - release_golang
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -5626,13 +5614,7 @@ jobs:
           npm deprecate @cdktf/provider-random "See https://cdk.tf/imports for details on how to continue to use the random provider in your CDK for Terraform (CDKTF) projects by generating the bindings locally."
   release_github:
     name: Publish to GitHub Releases
-    needs:
-      - release
-      - release_npm
-      - release_maven
-      - release_pypi
-      - release_nuget
-      - release_golang
+    needs: release
     runs-on: custom-linux-medium
     permissions:
       contents: write
@@ -8376,13 +8358,7 @@ jobs:
           npm deprecate @cdktf/provider-random "See https://cdk.tf/imports for details on how to continue to use the random provider in your CDK for Terraform (CDKTF) projects by generating the bindings locally."
   release_github:
     name: Publish to GitHub Releases
-    needs:
-      - release
-      - release_npm
-      - release_maven
-      - release_pypi
-      - release_nuget
-      - release_golang
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -11136,13 +11112,7 @@ jobs:
           npm deprecate @cdktf/provider-acme "See https://cdk.tf/imports for details on how to continue to use the acme provider in your CDK for Terraform (CDKTF) projects by generating the bindings locally."
   release_github:
     name: Publish to GitHub Releases
-    needs:
-      - release
-      - release_npm
-      - release_maven
-      - release_pypi
-      - release_nuget
-      - release_golang
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This used to be the default behavior but was changed in Projen in projen/projen#3526. This overrides the new behavior and reverts it to how it used to work originally.

I don't really know what problem that Projen PR was solving since you can retry individual failed steps in the release workflow; you don't have to retry the entire workflow.

On the other hand, I noticed a couple of months ago when we were having Maven publishing issues that this "fix" was actually _causing_ problems for us. Consider the following scenario:

1. Let's say we have _terraform-provider-example_ which is currently on v4.0.1, and _cdktf-provider-example_ which is currently on v12.0.1.
2. _terraform-provider-example_ publishes a new version, going from v4.0.1 -> v4.0.2
3. The nightly provider upgrade job for _cdktf-provider-example_ detects the change, generates the new code, and determines that this should be released as v12.0.2. The release publishes successfully to NPM, PyPi, NuGet, and the Go repository. However, the Maven release fails due to an API key issue, so a new GitHub tag and release are not created.
4. For whatever reason, we aren't able to promptly fix the Maven issue, and since it's not just a sporadic connection issue but something systemic like a bad API key, every attempt at a Maven release continues to fail.
5. _terraform-provider-example_ publishes a new version, going from v4.0.2 -> v4.0.3
6. The nightly provider upgrade job for _cdktf-provider-example_ detects the change, generates the new code, and determines (by looking at the GitHub tags) that this should be released as v12.0.2, not v12.0.3 -- that's because a new tag wasn't created in step 3 above. It now tries to publish a new v12.0.2 to the various package managers, even though this version already exists in NPM, PyPi, NuGet, and Go. I don't remember how every package manager deals with the issue but I do remember at the very least PyPi hard-errors out every time because you're trying to publish a version that already exists with different code than before.
7. Now every time a release is attempted hereafter, not only do you have broken Maven publishing, but broken PyPi publishing too.

I think the Projen change might make sense in situations where these packages are daily/actively maintained and we're able to jump on addressing publishing issues quickly. Since we're not that prompt, and we had already agreed in the past that we're OK with some package managers occasionally missing a patch or two here and there as long as they by and large successfully get all the important upgrades, I assume you'll agree that the Projen change makes things worse for us instead of better.

This is somewhat urgent right now because we're having NuGet publishing issues that may take some time to fix, so the above scenario is likely to start happening over the next few days, with NuGet in place of Maven.