### PR TITLE
fix(release): use correct steps when publishing Go modules

### DIFF
--- a/src/force-release.ts
+++ b/src/force-release.ts
@@ -78,7 +78,7 @@ export class ForceRelease {
         {
           name: "Upload artifact",
           uses: "actions/upload-artifact",
-          with: { name: "build-artifact", path: "dist" },
+          with: { name: "build-artifact", path: "dist", overwrite: true },
         },
       ],
     });
@@ -104,7 +104,7 @@ export class ForceRelease {
         {
           name: "Setup Go",
           uses: "actions/setup-go",
-          with: { "go-version": "^1.16.0" },
+          with: { "go-version": "^1.18.0" },
         },
         {
           name: "Download build artifacts",
@@ -117,15 +117,26 @@ export class ForceRelease {
           continueOnError: true,
         },
         {
-          name: "Prepare Repository",
-          run: "mv dist .repo",
+          name: "Checkout",
+          uses: "actions/checkout",
+          with: {
+            path: ".repo",
+          },
         },
         {
           name: "Install Dependencies",
           run: "cd .repo && yarn install --check-files --frozen-lockfile",
         },
         {
-          name: "Create Artifact",
+          name: "Extract build artifact",
+          run: "tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo",
+        },
+        {
+          name: "Move build artifact out of the way",
+          run: "mv dist dist.old",
+        },
+        {
+          name: "Create go artifact",
           run: "cd .repo && npx projen package:go",
         },
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,12 +175,23 @@ export class CdktfProviderProject extends cdk.JsiiProject {
         // If someone knows a better way to do this mutation with minimal custom code, please do so
         prePublishSteps: [
           {
-            name: "Prepare Repository",
-            run: "mv dist .repo",
+            name: "Checkout",
+            uses: "actions/checkout",
+            with: {
+              path: ".repo",
+            },
           },
           {
             name: "Install Dependencies",
             run: "cd .repo && yarn install --check-files --frozen-lockfile",
+          },
+          {
+            name: "Extract build artifact",
+            run: "tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo",
+          },
+          {
+            name: "Move build artifact out of the way",
+            run: "mv dist dist.old",
           },
           {
             name: "Create go artifact",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -881,10 +881,16 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
       - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool
@@ -2726,6 +2732,7 @@ jobs:
         with:
           name: build-artifact
           path: dist
+          overwrite: true
   force_release_golang:
     name: Publish to Github Go Repository
     needs: force-release
@@ -2741,7 +2748,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: ^1.16.0
+          go-version: ^1.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
@@ -2750,11 +2757,17 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create Artifact
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
@@ -3271,10 +3284,16 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
       - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool
@@ -5539,6 +5558,7 @@ jobs:
         with:
           name: build-artifact
           path: dist
+          overwrite: true
   force_release_golang:
     name: Publish to Github Go Repository
     needs: force-release
@@ -5554,7 +5574,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: ^1.16.0
+          go-version: ^1.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
@@ -5563,11 +5583,17 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create Artifact
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
@@ -6084,10 +6110,16 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
       - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool
@@ -8352,6 +8384,7 @@ jobs:
         with:
           name: build-artifact
           path: dist
+          overwrite: true
   force_release_golang:
     name: Publish to Github Go Repository
     needs: force-release
@@ -8367,7 +8400,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: ^1.16.0
+          go-version: ^1.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
@@ -8376,11 +8409,17 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create Artifact
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
@@ -8897,10 +8936,16 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
       - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool
@@ -11170,6 +11215,7 @@ jobs:
         with:
           name: build-artifact
           path: dist
+          overwrite: true
   force_release_golang:
     name: Publish to Github Go Repository
     needs: force-release
@@ -11186,7 +11232,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: ^1.16.0
+          go-version: ^1.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
@@ -11195,11 +11241,17 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create Artifact
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
@@ -11720,10 +11772,16 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
-      - name: Prepare Repository
-        run: mv dist .repo
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          path: .repo
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
       - name: Create go artifact
         run: cd .repo && npx projen package:go
       - name: Setup Copywrite tool


### PR DESCRIPTION
For future reference, what ended up being helpful in finding the issue was comparing the publishing steps in this repo with [the ones for cdktf-tf-module-stack](https://github.com/cdktf/cdktf-tf-module-stack/blob/309f6826e9835b68dd2925d62cd33cd58e2145a1/.github/workflows/release.yml#L256-L297), which is the one other project that we have that uses Projen to publish Go modules.