### PR TITLE
chore(deps): upgrade JSII & TypeScript for this package only

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -94,12 +94,12 @@
     },
     {
       "name": "jsii-rosetta",
-      "version": "~5.3.0",
+      "version": "~5.4.0",
       "type": "build"
     },
     {
       "name": "jsii",
-      "version": "~5.3.0",
+      "version": "~5.4.0",
       "type": "build"
     },
     {
@@ -120,7 +120,7 @@
     },
     {
       "name": "typescript",
-      "version": "~5.3.0",
+      "version": "~5.4.0",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -37,8 +37,8 @@ const project = new cdk.JsiiProject({
   authorOrganization: true,
   licensed: false, // we do supply our own license file with a custom header
   pullRequestTemplate: false,
-  jsiiVersion: "~5.3.0",
-  typescriptVersion: "~5.3.0", // should always be the same major/minor as JSII
+  jsiiVersion: "~5.4.0",
+  typescriptVersion: "~5.4.0", // should always be the same major/minor as JSII
   peerDeps: ["projen@^0.87.4", "constructs@^10.3.0"],
   deps: ["change-case", "fs-extra"],
   bundledDeps: ["change-case", "fs-extra"],

--- a/package.json
+++ b/package.json
@@ -54,16 +54,16 @@
     "glob": "^7.2.3",
     "jest": "^29",
     "jest-junit": "^15",
-    "jsii": "~5.3.0",
+    "jsii": "~5.4.0",
     "jsii-diff": "^1.103.1",
     "jsii-docgen": "^10.5.0",
     "jsii-pacmak": "^1.103.1",
-    "jsii-rosetta": "~5.3.0",
+    "jsii-rosetta": "~5.4.0",
     "prettier": "^2.8.8",
     "projen": "0.87.4",
     "ts-jest": "^29",
     "ts-node": "^10.9.2",
-    "typescript": "~5.3.0"
+    "typescript": "~5.4.0"
   },
   "peerDependencies": {
     "constructs": "^10.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,10 +3588,10 @@ jsii-reflect@^1.103.1:
     oo-ascii-tree "^1.103.1"
     yargs "^16.2.0"
 
-jsii-rosetta@~5.3.0:
-  version "5.3.54"
-  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-5.3.54.tgz#a911f8219b05ae7111a4a6fec6fbb4560463b97b"
-  integrity sha512-qmGyxwJeJRq8Bw+WGcKBCpfyggNOpCCNPLX5DchewNvw0sebikdF1Y4vUZtUi0PjIEsOSntK6bi09dDzNLbp8w==
+jsii-rosetta@~5.4.0:
+  version "5.4.36"
+  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-5.4.36.tgz#394fa5a9daa7790c55041524158b0e852d49daa5"
+  integrity sha512-7rYdbq0NCTID6XSxJYZkMLfrO+8loO2ZSlokVLgAeEQ1YSwF6ydqLHuFkYr4iZwpugLSSLVDRi8q+e6aHh9XBA==
   dependencies:
     "@jsii/check-node" "1.103.1"
     "@jsii/spec" "^1.103.1"
@@ -3599,18 +3599,18 @@ jsii-rosetta@~5.3.0:
     chalk "^4"
     commonmark "^0.31.1"
     fast-glob "^3.3.2"
-    jsii "~5.3.0"
+    jsii "~5.4.0"
     semver "^7.6.3"
     semver-intersect "^1.5.0"
     stream-json "^1.8.0"
-    typescript "~5.3"
+    typescript "~5.4"
     workerpool "^6.5.1"
     yargs "^17.7.2"
 
-jsii@~5.3.0:
-  version "5.3.55"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.3.55.tgz#a220d9bffdad9331cb4c4345e8b3192258755c4c"
-  integrity sha512-CCM5ch6a+TDSDMt3VwUP3M5qHS2dC0sXciT1X7hv2uZpn88Yjh6gulCukrzS31Ndvgz4zS9xZ5ij6PSMIbUwLg==
+jsii@~5.4.0:
+  version "5.4.36"
+  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.4.36.tgz#376afc0553b44d81abd83f7e95927e831a652fce"
+  integrity sha512-bFd+CJ2gqtJi49Nx1i76d22VJj6gi+Ztq5OZk3mCmkGzzXhV7F3TC4Cf4Z4mJjjCbr5693SXYRZmk5SkpJvt9A==
   dependencies:
     "@jsii/check-node" "1.103.1"
     "@jsii/spec" "^1.103.1"
@@ -3623,7 +3623,7 @@ jsii@~5.3.0:
     semver-intersect "^1.5.0"
     sort-json "^2.0.1"
     spdx-license-list "^6.9.0"
-    typescript "~5.3"
+    typescript "~5.4"
     yargs "^17.7.2"
 
 json-buffer@3.0.1:
@@ -5137,10 +5137,10 @@ typescript@next:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.0-dev.20240929.tgz#60cdc36d29570e0aed32ec10e3894372b81a6312"
   integrity sha512-qcghiX+nPjUkCRJW95fqZiemaj+b/2ljt46UliUqjbhbolAX1o1TzavEYuwlv3JHqcBT9WjaPNf8+OyzovyQMw==
 
-typescript@~5.3, typescript@~5.3.0:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
-  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+typescript@~5.4, typescript@~5.4.0:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
This upgrade does not apply to the prebuilt providers themselves, which were already on v5.4 anyway.
