### PR TITLE
chore(ci): set Node.js version in all workflows

### DIFF
--- a/src/deprecate-packages.ts
+++ b/src/deprecate-packages.ts
@@ -55,6 +55,13 @@ export class DeprecatePackages {
             uses: "actions/checkout@v4",
           },
           {
+            name: "Setup Node.js",
+            uses: "actions/setup-node",
+            with: {
+              "node-version": project.minNodeVersion,
+            },
+          },
+          {
             name: "Install",
             run: "yarn install",
           },

--- a/src/provider-upgrade.ts
+++ b/src/provider-upgrade.ts
@@ -58,6 +58,13 @@ export class ProviderUpgrade {
             name: "Checkout",
             uses: "actions/checkout@v4",
           },
+          {
+            name: "Setup Node.js",
+            uses: "actions/setup-node",
+            with: {
+              "node-version": project.minNodeVersion,
+            },
+          },
           { run: "yarn install" },
           {
             id: "check_version",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -580,6 +580,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with: {}
       - name: Install
         run: yarn install
       - name: Check deprecation status
@@ -2838,6 +2841,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with: {}
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -2983,6 +2989,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with: {}
       - name: Install
         run: yarn install
       - name: Check deprecation status
@@ -5664,6 +5673,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with: {}
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -5809,6 +5821,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with: {}
       - name: Install
         run: yarn install
       - name: Check deprecation status
@@ -8490,6 +8505,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with: {}
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -8635,6 +8653,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with: {}
       - name: Install
         run: yarn install
       - name: Check deprecation status
@@ -11322,6 +11343,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with:
+          node-version: 18.12.0
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -11471,6 +11496,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with:
+          node-version: 18.12.0
       - name: Install
         run: yarn install
       - name: Check deprecation status


### PR DESCRIPTION
This is probably important because of the changes in https://github.com/projen/projen/releases/tag/v0.88.0 -- let's make sure we're consistent about the version of Node.js being used in all our workflows.