### PR TITLE
chore(ci): don't cancel-in-progress auto-approve and automerge workflows

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,7 +10,6 @@ on:
       - reopened
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,7 +11,6 @@ on:
       - synchronize
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   automerge:
     runs-on: ubuntu-latest

--- a/src/auto-approve.ts
+++ b/src/auto-approve.ts
@@ -23,7 +23,6 @@ export class AutoApprove {
 
     (workflow.concurrency as any) = {
       group: "${{ github.workflow }}-${{ github.head_ref }}",
-      cancelInProgress: true,
     };
 
     const maintainerStatuses = `fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]')`;

--- a/src/automerge.ts
+++ b/src/automerge.ts
@@ -29,7 +29,6 @@ export class Automerge {
 
     (workflow.concurrency as any) = {
       group: "${{ github.workflow }}-${{ github.head_ref }}",
-      cancelInProgress: true,
     };
 
     const maintainerStatuses = `fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]')`;

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -79,7 +79,6 @@ on:
       - reopened
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   approve:
     runs-on: ubuntu-latest
@@ -173,7 +172,6 @@ on:
       - synchronize
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   automerge:
     runs-on: ubuntu-latest
@@ -2325,7 +2323,6 @@ on:
       - reopened
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   approve:
     runs-on: ubuntu-latest
@@ -2419,7 +2416,6 @@ on:
       - synchronize
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   automerge:
     runs-on: ubuntu-latest
@@ -5180,7 +5176,6 @@ on:
       - reopened
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   approve:
     runs-on: ubuntu-latest
@@ -5274,7 +5269,6 @@ on:
       - synchronize
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   automerge:
     runs-on: ubuntu-latest
@@ -8031,7 +8025,6 @@ on:
       - reopened
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   approve:
     runs-on: ubuntu-latest
@@ -8125,7 +8118,6 @@ on:
       - synchronize
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   automerge:
     runs-on: ubuntu-latest
@@ -10886,7 +10878,6 @@ on:
       - reopened
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   approve:
     runs-on: ubuntu-latest
@@ -10980,7 +10971,6 @@ on:
       - synchronize
 concurrency:
   group: \${{ github.workflow }}-\${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   automerge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This did not turn out to be helpful, as it's just leading to more stale PRs because sometimes the workflow fails to trigger at all.