### PR TITLE
chore(ci): remove unnecessary compile step from workflow

### DIFF
--- a/src/provider-upgrade.ts
+++ b/src/provider-upgrade.ts
@@ -101,9 +101,6 @@ export class ProviderUpgrade {
           `echo "type=$SEMANTIC_TYPE" >> $GITHUB_OUTPUT`,
         ].join("\n"),
       },
-      // generate docs
-      { run: "yarn compile", if: newerVersionAvailable },
-      { run: "yarn docgen", if: newerVersionAvailable },
       // submit a PR
       {
         name: "Create Pull Request",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2905,10 +2905,6 @@ jobs:
           [[ "$IS_MINOR_RELEASE" == "true" ]] && SEMANTIC_TYPE=feat || SEMANTIC_TYPE=fix
           echo "is_minor=$IS_MINOR_RELEASE" >> $GITHUB_OUTPUT
           echo "type=$SEMANTIC_TYPE" >> $GITHUB_OUTPUT
-      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
-        run: yarn compile
-      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
-        run: yarn docgen
       - name: Create Pull Request
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
@@ -5754,10 +5750,6 @@ jobs:
           [[ "$IS_MINOR_RELEASE" == "true" ]] && SEMANTIC_TYPE=feat || SEMANTIC_TYPE=fix
           echo "is_minor=$IS_MINOR_RELEASE" >> $GITHUB_OUTPUT
           echo "type=$SEMANTIC_TYPE" >> $GITHUB_OUTPUT
-      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
-        run: yarn compile
-      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
-        run: yarn docgen
       - name: Create Pull Request
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
@@ -8607,10 +8599,6 @@ jobs:
           [[ "$IS_MINOR_RELEASE" == "true" ]] && SEMANTIC_TYPE=feat || SEMANTIC_TYPE=fix
           echo "is_minor=$IS_MINOR_RELEASE" >> $GITHUB_OUTPUT
           echo "type=$SEMANTIC_TYPE" >> $GITHUB_OUTPUT
-      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
-        run: yarn compile
-      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
-        run: yarn docgen
       - name: Create Pull Request
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
@@ -11467,10 +11455,6 @@ jobs:
           [[ "$IS_MINOR_RELEASE" == "true" ]] && SEMANTIC_TYPE=feat || SEMANTIC_TYPE=fix
           echo "is_minor=$IS_MINOR_RELEASE" >> $GITHUB_OUTPUT
           echo "type=$SEMANTIC_TYPE" >> $GITHUB_OUTPUT
-      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
-        run: yarn compile
-      - if: \${{ steps.check_version.outputs.new_version == 'available' }}
-        run: yarn docgen
       - name: Create Pull Request
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e


### PR DESCRIPTION
We've been having problems recently with automated upgrade workflows for AWS, Azure, and Google(beta) habitually failing:

<img width="892" alt="Screenshot 2025-03-31 at 15 34 53" src="https://github.com/user-attachments/assets/026c5366-766e-4d83-9160-317b0edb399a" />

What's particularly interesting is that it fails during the PR creation step. More specifically: the PR itself gets created successfully, but the "automerge" and "auto-approve" labels don't get applied, and the `peter-evans/create-pull-request` action considers this a failure of the entire workflow step even though the PR did get created. It's interesting because lately this is failing pretty much 100% of the time for the major cloud providers, but it hasn't been happening for any other providers, leading me to believe it has to do with the size of the providers.

I realized a while back that these workflows include a `compile` step that as far as I know (and this is where I'm looking for reviews; let me know if this is a wrong assumption) that's actually unnecessary; the `build` workflow that runs after the PR gets created will run `compile` and `docgen` as part of the process, and if there are indeed any changes resulting from running those steps, Projen will generate a `self-mutation` commit with the results. In other words: I think we can skip running `compile` _before_ the PR gets created and just let Projen handle that via self-mutation afterwards.

In this way, we can vastly reduce the size of the generated PRs, and I assume that'll have an effect on these workflows succeeding.

See also cdktf/cdktf-repository-manager#370 for a companion PR -- this logic (that compiles the provider before PR creation) is essentially duplicated in two places, so both of these need to be merged for the problem to be addressed.