### PR TITLE
chore(ci): add missing setup-terraform step to workflow

### DIFF
--- a/src/provider-upgrade.ts
+++ b/src/provider-upgrade.ts
@@ -53,6 +53,13 @@ export class ProviderUpgrade {
         uses: "actions/checkout",
       },
       {
+        name: "Setup Terraform",
+        uses: "hashicorp/setup-terraform",
+        with: {
+          terraform_wrapper: false,
+        },
+      },
+      {
         name: "Setup Node.js",
         uses: "actions/setup-node",
         with: {
@@ -120,19 +127,6 @@ export class ProviderUpgrade {
         },
       },
     ];
-
-    // @TODO Figure out if this is really necessary; this has not been tested
-    // But I saw https://github.com/hashicorp/setup-terraform/issues/425
-    // so I added this "if" statement as a precaution
-    if (options.workflowRunsOn.includes("ubuntu-latest")) {
-      steps.splice(2, 0, {
-        name: "Setup Terraform",
-        uses: "hashicorp/setup-terraform",
-        with: {
-          terraform_wrapper: false,
-        },
-      });
-    }
 
     workflow.addJobs({
       upgrade: {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2869,13 +2869,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Setup Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
-        with: {}
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
           terraform_wrapper: false
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+        with: {}
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -5718,6 +5718,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_wrapper: false
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with: {}
@@ -8563,13 +8567,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Setup Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
-        with: {}
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
           terraform_wrapper: false
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+        with: {}
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -11418,14 +11422,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - name: Setup Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
-        with:
-          node-version: 18.12.0
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
           terraform_wrapper: false
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+        with:
+          node-version: 18.12.0
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version


### PR DESCRIPTION
We upgraded our custom runners to Ubuntu 24.04 yesterday, but it seems like these images no longer have Terraform installed on the command line anymore, so we now need to use the `setup-terraform` step for both custom runners and the default ones.

Without this fix, the nightly provider-upgrade jobs for big providers like Google and AWS will fail.