### PR TITLE
refactor: make force-release workflow more resilient

### DIFF
--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -12027,17 +12027,20 @@ jobs:
         with:
           node-version: 18.12.0
       - name: Install dependencies
-        run: npx projen unconditional-release
+        run: yarn install --check-files --frozen-lockfile
       - name: release
-        run: npx projen release
-      - name: Check for new commits or cancel via faking a SHA if release was cancelled
-        id: git_remote
-        run: node ./scripts/should-release.js && (echo "latest_commit=$(git ls-remote origin -h \${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT && cat $GITHUB_OUTPUT) || echo "latest_commit=release_cancelled" >> $GITHUB_OUTPUT
+        run: npx projen unconditional-release
+      - name: Check if version has already been tagged
+        id: check_tag_exists
+        run: |-
+          if [ ! -f dist/releasetag.txt ]; then (echo "exists=true" >> $GITHUB_OUTPUT) && exit 0; fi
+          TAG=$(cat dist/releasetag.txt)
+          ([ ! -z "$TAG" ] && git ls-remote -q --exit-code --tags origin $TAG && (echo "exists=true" >> $GITHUB_OUTPUT)) || (echo "exists=false" >> $GITHUB_OUTPUT)
+          cat $GITHUB_OUTPUT
       - name: Backup artifact permissions
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: build-artifact


### PR DESCRIPTION
Turns out hard-coding array indices is a bad idea because they may not always be the same across all projects! Who woulda thunk it...