### PR TITLE
chore(ci): run copywrite after fetch

### DIFF
--- a/src/provider-upgrade.ts
+++ b/src/provider-upgrade.ts
@@ -66,6 +66,10 @@ export class ProviderUpgrade {
           "node-version": project.minNodeVersion,
         },
       },
+      {
+        name: "Setup Copywrite tool",
+        uses: "hashicorp/setup-copywrite",
+      },
       { run: "yarn install" },
       {
         id: "check_version",
@@ -84,6 +88,12 @@ export class ProviderUpgrade {
           CHECKPOINT_DISABLE: "1",
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
         },
+      },
+      {
+        // Because yarn fetch nukes the contents of /src, we've lost our auto-generated copyright headers
+        name: "Add headers using Copywrite tool",
+        if: newerVersionAvailable,
+        run: "copywrite headers",
       },
       {
         name: "get provider updated version",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -3088,6 +3088,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with: {}
+      - name: Setup Copywrite tool
+        uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -3100,6 +3102,9 @@ jobs:
           CHECKPOINT_DISABLE: "1"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
+      - name: Add headers using Copywrite tool
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: copywrite headers
       - name: get provider updated version
         id: new_version
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
@@ -6175,6 +6180,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with: {}
+      - name: Setup Copywrite tool
+        uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -6187,6 +6194,9 @@ jobs:
           CHECKPOINT_DISABLE: "1"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
+      - name: Add headers using Copywrite tool
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: copywrite headers
       - name: get provider updated version
         id: new_version
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
@@ -9262,6 +9272,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with: {}
+      - name: Setup Copywrite tool
+        uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -9274,6 +9286,9 @@ jobs:
           CHECKPOINT_DISABLE: "1"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
+      - name: Add headers using Copywrite tool
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: copywrite headers
       - name: get provider updated version
         id: new_version
         if: \${{ steps.check_version.outputs.new_version == 'available' }}
@@ -12358,6 +12373,8 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 18.12.0
+      - name: Setup Copywrite tool
+        uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
       - run: yarn install
       - id: check_version
         run: yarn check-if-new-provider-version
@@ -12370,6 +12387,9 @@ jobs:
           CHECKPOINT_DISABLE: "1"
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: yarn fetch
+      - name: Add headers using Copywrite tool
+        if: \${{ steps.check_version.outputs.new_version == 'available' }}
+        run: copywrite headers
       - name: get provider updated version
         id: new_version
         if: \${{ steps.check_version.outputs.new_version == 'available' }}


### PR DESCRIPTION
Companion to cdktf/cdktf-repository-manager#391. This isn't a major issue since the copyright headers do get added eventually (during the `self-mutation` step as part of the `build` CI workflow after the PR gets created) but if we _know_ that the headers need to be recreated anyway because `fetch` nuked them, then we might as well do it up-front.